### PR TITLE
Require sandboxed local benchmark grading

### DIFF
--- a/docs/RECIPES.md
+++ b/docs/RECIPES.md
@@ -77,8 +77,10 @@ from proteus.bench import as_goal
 from proteus.bench.local import local_task
 from proteus.core import Visibility
 from proteus.core.episode import RunConfig, run
+from proteus.sandbox import DockerSandbox, SandboxConfig
 
-task = local_task("local:interval-merge")        # offline; no Docker, no dataset
+grader = DockerSandbox(SandboxConfig(image="python:3.12-slim", network="none"))
+task = local_task("local:interval-merge", sandbox=grader)  # no dataset; agent code stays isolated
 cfg = RunConfig(name="goal-observe", adapter=..., disposition=...,
                 goal=as_goal(task, visibility=Visibility.OBSERVE),
                 root=..., model=..., episodes=30, task=task)

--- a/proteus/bench/local.py
+++ b/proteus/bench/local.py
@@ -4,12 +4,11 @@ Docker-graded suites (see `swe.py`) are the high-fidelity option and cost tens o
 container per instance. Most iteration does not need that: to ask whether a *goal* changes
 what a harness evolves into, what matters is a stable scalar reward, not a leaderboard
 number. This pack gives one — seeded bugs in a tiny repo, graded by running its tests, with
-no network, no images, and no dataset download.
+no network or dataset download.
 
 **Containment.** Grading runs code the agent wrote. That is exactly the capability that
 escaped an application-level sandbox in our own runs, so the grader must run under the same
-isolation as the episode: pass a `Sandbox`, or accept that `LocalSandbox` is no isolation
-at all and only use it for harnesses you trust.
+isolation as the episode: pass a `Sandbox`, or explicitly opt into trusted host execution.
 """
 
 from __future__ import annotations
@@ -22,6 +21,7 @@ from pathlib import Path
 
 from proteus.bench.task import BenchTask
 from proteus.core.goal import EvalResult
+from proteus.sandbox import LocalSandbox, Sandbox
 
 GRADE_TIMEOUT_S = 60
 
@@ -142,15 +142,21 @@ def _write_pack(ws: Path, key: str) -> None:
     # so the seed is preserved in the task spec, not in a sub-repo.
 
 
-def _grade(ws: Path, key: str) -> EvalResult:
+def _grade(ws: Path, key: str, sandbox: Sandbox | None) -> EvalResult:
     # grade against the held-out tests: restore tests.py from the spec first, so an agent
     # that "passes" by editing the tests (the reward-hack this setup invites) gains nothing
     (ws / "tests.py").write_text(textwrap.dedent(_TASKS[key]["tests"]), encoding="utf-8")
     (ws / "_grade.py").write_text(_DRIVER, encoding="utf-8")
     try:
-        proc = subprocess.run([sys.executable, "_grade.py"], cwd=str(ws),
-                              capture_output=True, text=True, timeout=GRADE_TIMEOUT_S,
-                              check=False)
+        if sandbox is None or isinstance(sandbox, LocalSandbox):
+            proc = subprocess.run([sys.executable, "_grade.py"], cwd=str(ws),
+                                  capture_output=True, text=True, timeout=GRADE_TIMEOUT_S,
+                                  check=False)
+        else:
+            proc = sandbox.run(
+                ws, ["python3", "/workspace/_grade.py"], {}, GRADE_TIMEOUT_S,
+                mounts=((str(ws.resolve()), "/workspace"),),
+            )
     except subprocess.TimeoutExpired:
         return EvalResult(name=key, score=0.0, passed=False,
                           detail=f"grading timed out after {GRADE_TIMEOUT_S}s")
@@ -169,15 +175,23 @@ def _grade(ws: Path, key: str) -> EvalResult:
                              + (f"; failing: {rep['failed'][:3]}" if n_bad else ""))
 
 
-def local_task(key: str) -> BenchTask:
-    """One task from the built-in pack. `proteus.bench.local.TASKS` lists the keys."""
+def local_task(key: str, *, sandbox: Sandbox | None = None,
+               trusted_local: bool = False) -> BenchTask:
+    """One built-in task, graded in `sandbox` unless trusted host execution is explicit."""
     if key not in _TASKS:
         raise KeyError(f"unknown local task {key!r}; have {sorted(_TASKS)}")
+    if sandbox is None and not trusted_local:
+        raise ValueError(
+            "local_task grades agent-authored Python; pass an isolated sandbox or set "
+            "trusted_local=True only for code you trust"
+        )
+    if isinstance(sandbox, LocalSandbox) and not trusted_local:
+        raise ValueError("LocalSandbox is not isolation; set trusted_local=True to use it")
     return BenchTask(
         id=key,
         goal_text=_TASKS[key]["goal"],
         setup=lambda ws, k=key: _write_pack(ws, k),
-        grade=lambda ws, k=key: _grade(ws, k),
+        grade=lambda ws, k=key, s=sandbox: _grade(ws, k, s),
     )
 
 

--- a/tests/test_bench.py
+++ b/tests/test_bench.py
@@ -12,7 +12,7 @@ from proteus.core.episode import RunConfig, run
 def test_seeded_tasks_start_failing(tmp_path):
     # a task whose seed already passes is a dead reward signal
     for key in TASKS:
-        task = local_task(key)
+        task = local_task(key, trusted_local=True)
         ws = tmp_path / key.replace(":", "_")
         ws.mkdir()
         task.setup(ws)
@@ -22,7 +22,7 @@ def test_seeded_tasks_start_failing(tmp_path):
 
 
 def test_grader_rewards_a_fix(tmp_path):
-    task = local_task("local:interval-merge")
+    task = local_task("local:interval-merge", trusted_local=True)
     ws = tmp_path / "task"
     ws.mkdir()
     task.setup(ws)
@@ -57,7 +57,7 @@ def test_diff_shows_only_the_agents_edit(tmp_path):
 
 def test_local_grader_ignores_edited_tests(tmp_path):
     # editing tests.py must not raise the score: the grader restores held-out tests
-    task = local_task("local:interval-merge")
+    task = local_task("local:interval-merge", trusted_local=True)
     ws = tmp_path / "task"
     ws.mkdir()
     task.setup(ws)
@@ -68,7 +68,7 @@ def test_local_grader_ignores_edited_tests(tmp_path):
 
 
 def test_goal_conditioned_run_seeds_and_scores(tmp_path):
-    task = local_task("local:interval-merge")
+    task = local_task("local:interval-merge", trusted_local=True)
     cfg = RunConfig(name="goal", adapter=MinimalHarness(), disposition=NEUTRAL,
                     goal=as_goal(task, visibility=Visibility.OBSERVE),
                     root=tmp_path / "run", model="mock", episodes=2, seed=0, task=task)
@@ -78,3 +78,35 @@ def test_goal_conditioned_run_seeds_and_scores(tmp_path):
     assert (ws / "solution.py").is_file()        # seeded before episode 1
     assert all(h["results"] for h in res.eval_history)   # scored every episode
     assert res.eval_history[0]["results"][0]["name"] == task.id
+
+
+def test_local_task_refuses_implicit_host_execution():
+    try:
+        local_task("local:interval-merge")
+    except ValueError as exc:
+        assert "isolated sandbox" in str(exc)
+    else:
+        raise AssertionError("local_task allowed agent-authored code to run on the host")
+
+
+def test_local_task_routes_grading_through_the_sandbox(tmp_path):
+    import subprocess
+
+    seen = {}
+
+    class RecordingSandbox:
+        def run(self, run_root, command, env, timeout_s, mounts=()):
+            seen.update(run_root=run_root, command=command, env=env,
+                        timeout_s=timeout_s, mounts=mounts)
+            return subprocess.CompletedProcess(
+                command, 0, '{"passed":["test_ok"],"failed":[]}\n', "")
+
+    task = local_task("local:interval-merge", sandbox=RecordingSandbox())
+    ws = tmp_path / "task"
+    ws.mkdir()
+    task.setup(ws)
+    result = task.grade(ws)
+
+    assert result.passed
+    assert seen["command"] == ["python3", "/workspace/_grade.py"]
+    assert seen["mounts"] == ((str(ws.resolve()), "/workspace"),)


### PR DESCRIPTION
## Summary

- require an isolated Sandbox for local benchmark grading by default
- keep host execution available only through explicit trusted_local=True
- run sandboxed graders with only the task workspace mounted
- document the safe Docker-backed setup

## Why

The local grader imports and executes agent-authored solution.py. Previously it launched that code with the host's Python process even when the agent episode itself ran in Docker, crossing the intended isolation boundary.

## Tests

- PYTHONPATH=. python3 tests/run_offline.py — 36 passed
- ruff check . — passed