### PR TITLE
Fix staged runtime mounts and preserve failed retries

### DIFF
--- a/proteus/adapters/dsh.py
+++ b/proteus/adapters/dsh.py
@@ -333,6 +333,16 @@ class DshHarness:
         # Keep the legacy preflight only for direct adapter use without an active_root.
         if spec.active_root is None and (harness / "src").is_dir():
             error = self.check_boot(harness)
+        if spec.active_root is not None:
+            # Docker cannot create a nested bind target after its parent has been mounted
+            # read-only.  Materialised snapshots intentionally contain only harness files,
+            # so reserve the framework-owned mount points before /workspace becomes ro.
+            # The directories live only in the disposable active copy and are hidden by
+            # the candidate/handoff mounts inside the container.
+            (active / "candidate").mkdir(exist_ok=True)
+            (active / ".proteus").mkdir(exist_ok=True)
+            if (run_root / "task").is_dir():
+                (active / "task").mkdir(exist_ok=True)
         workspace_mounts = ((str(active), "/workspace", "ro"),
                             (str(harness), "/workspace/candidate")) \
             if spec.active_root is not None else ((str(harness), "/workspace"),)

--- a/proteus/adapters/pi.py
+++ b/proteus/adapters/pi.py
@@ -240,6 +240,14 @@ class PiHarness:
         # Keep the legacy preflight only for direct adapter use without an active_root.
         if spec.active_root is None and (harness / "src").is_dir():
             error = self.check_boot(harness)
+        if spec.active_root is not None:
+            # Nested bind targets must exist before Docker mounts /workspace read-only.
+            # These placeholders belong to the disposable active copy and are obscured by
+            # the writable candidate/framework mounts in the running container.
+            (active / "candidate").mkdir(exist_ok=True)
+            (active / ".proteus").mkdir(exist_ok=True)
+            if (run_root / "task").is_dir():
+                (active / "task").mkdir(exist_ok=True)
         workspace_mounts = ((str(active), "/workspace", "ro"),
                             (str(harness), "/workspace/candidate")) \
             if spec.active_root is not None else ((str(harness), "/workspace"),)

--- a/proteus/core/snapshot.py
+++ b/proteus/core/snapshot.py
@@ -144,13 +144,23 @@ def preserve_failed_candidate(work_tree: Path, restore_sha: str, episode: int,
     Unlike a scored rejection, an interrupted/infrastructure-failed episode is not a
     completed episode and must not advance the ``episode N`` mapping. Moving HEAD back
     after restoring lets resume retry the same episode, while the candidate remains
-    inspectable under ``refs/proteus/candidates/episode-N-failed``.
+    inspectable under ``refs/proteus/candidates/episode-N-failed``. Retries never
+    overwrite that first failure: later attempts use ``...-attempt-2``,
+    ``...-attempt-3``, and so on.
     """
     candidate = ""
     try:
         candidate = commit(work_tree, message)
-        _git(work_tree, "update-ref",
-             f"refs/proteus/candidates/episode-{episode}-failed", candidate)
+        base = f"refs/proteus/candidates/episode-{episode}-failed"
+        existing = set(_git(
+            work_tree, "for-each-ref", "--format=%(refname)", f"{base}*"
+        ).splitlines())
+        ref = base
+        attempt = 2
+        while ref in existing:
+            ref = f"{base}-attempt-{attempt}"
+            attempt += 1
+        _git(work_tree, "update-ref", ref, candidate)
     finally:
         reset_to_checkpoint(work_tree, restore_sha)
     return candidate

--- a/tests/test_instrument.py
+++ b/tests/test_instrument.py
@@ -205,6 +205,33 @@ def test_incomplete_episode_preserves_candidate_ref_and_restores_checkpoint(tmp_
     assert preserved == "keep for analysis\n"
 
 
+def test_retried_incomplete_episode_keeps_each_failed_candidate(tmp_path):
+    harness = tmp_path / "retry" / "harness"
+    harness.mkdir(parents=True)
+    (harness / "state.txt").write_text("valid")
+    snapshot.init(harness)
+    checkpoint = snapshot.head(harness)
+
+    (harness / "state.txt").write_text("first failure")
+    first = snapshot.preserve_failed_candidate(harness, checkpoint, 1, "first")
+    (harness / "state.txt").write_text("second failure")
+    second = snapshot.preserve_failed_candidate(harness, checkpoint, 1, "second")
+
+    git_dir = harness.parent / ".snapshot.git"
+    refs = []
+    for ref in (
+        "refs/proteus/candidates/episode-1-failed",
+        "refs/proteus/candidates/episode-1-failed-attempt-2",
+    ):
+        refs.append(subprocess.run(
+            ["git", "--git-dir", str(git_dir), "rev-parse", ref],
+            capture_output=True, text=True, check=True,
+        ).stdout.strip())
+    assert refs == [first, second]
+    assert (harness / "state.txt").read_text() == "valid"
+    assert snapshot.head(harness) == checkpoint
+
+
 # ------------------------------------------------------------------- unit identity
 
 def test_directory_units_see_every_member(tmp_path):

--- a/tests/test_selfcode.py
+++ b/tests/test_selfcode.py
@@ -202,6 +202,8 @@ def test_staged_episode_mounts_frozen_active_read_only_and_candidate_writable(tm
         assert len(phase_calls) == 4
         assert not [call for call in sandbox.calls if call["command"] == ["--version"]], \
             "a staged episode must not preflight the writable candidate before its phases"
+        assert (active / "candidate").is_dir()
+        assert (active / ".proteus").is_dir()
         for call in phase_calls:
             mounts = call["mounts"]
             assert (str(active), "/workspace", "ro") in mounts


### PR DESCRIPTION
## Summary
- pre-create nested Docker bind targets before mounting the active harness read-only
- apply the staged-runtime fix to both DSH and Pi adapters
- preserve every failed retry under numbered candidate refs instead of overwriting the first failure

## Verification
- 100 tests passed on latest `main`
- live DSH rc.8 Episode 4 launched with `/workspace` read-only and candidate/handoff mounts writable