### PR TITLE
feat: contributor on-ramp — conformance gate, templates, scaffolder, docs

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,0 +1,127 @@
+# Contributing to Proteus
+
+Proteus is a harness-agnostic driver for measuring agent self-evolution. It knows nothing
+about any specific agent framework — it talks only to a `HarnessAdapter`, and it scores
+tasks through a `BenchTask`. The two highest-value contributions are therefore **new
+harness adapters** (evolve another agent framework) and **new benchmarks** (measure under
+more goals). Both are single-file, contract-checked, CI-gated additions. This guide shows
+the path; see [`ROADMAP.md`](ROADMAP.md) for what's wanted.
+
+## Dev setup
+
+```bash
+python -m pip install -e '.[dev]'                # add ',dsh,pi' to work on those adapters
+git config --global user.email you@example.com   # snapshot tests need a git identity
+git config --global user.name  "Your Name"
+```
+
+The gate every change must pass (this is exactly what CI runs):
+
+```bash
+ruff check .
+pytest tests/ -q
+python tests/run_offline.py     # the no-pytest path must stay alive (stdlib + python3)
+```
+
+Style: ruff with `line-length = 100`. A handful of pyupgrade rules are intentionally off
+so `tests/run_offline.py` can import the package under a stock macOS `python3` (3.9) — see
+`[tool.ruff.lint]` in `pyproject.toml`. Don't reach for `X | None` / `collections.abc` in
+code that path imports.
+
+## Adding a harness adapter
+
+An adapter is one class implementing seven methods (see the fully-commented
+[`examples/adapter_template.py`](examples/adapter_template.py) and the contract in
+[`proteus/core/adapter.py`](proteus/core/adapter.py)). The framework handles episodes,
+snapshots, dispositions, goals, and measurement; you provide the harness-specific glue.
+
+1. **Scaffold** a skeleton from the template:
+
+   ```bash
+   python -m proteus.scaffold adapter MyHarness      # -> proteus/adapters/myharness.py
+   ```
+
+2. **Implement the TODOs.** In order of effort:
+   - `surfaces()` — declare each persistent, agent-editable region (memory / skills /
+     tools / code); the measurement layer iterates this manifest.
+   - `seed()` / `install_disposition()` / `disposition_fingerprint()` — provisioning and
+     the removable perturbation. Reinstalling `NEUTRAL` **must** restore the fingerprint.
+   - `run_episode()` / `read_trace()` — run one context-fresh episode against your loop
+     and emit a normalized action trace. This is the real work; for a containerized,
+     rebuild-from-source harness copy the pattern in
+     [`proteus/adapters/dsh.py`](proteus/adapters/dsh.py) /
+     [`pi.py`](proteus/adapters/pi.py). For an offline reference, read
+     [`proteus/adapters/minimal.py`](proteus/adapters/minimal.py).
+   - *Optional attributes* for advanced harnesses (all default safely if omitted):
+     `continuity_mode` (`"native"` / `"framework"` / `"none"` — how fresh phases
+     continue) and, for a harness whose own edited files change how it runs,
+     `staged_activation = True` plus an optional `validate_candidate()` so an edit only
+     takes effect the next episode. See the notes in `proteus/core/adapter.py`.
+
+3. **Check the contract.** Free static + provisioning checks run anywhere; `--episode`
+   actually runs one neutral episode (may launch containers / call a model):
+
+   ```bash
+   proteus check --harness proteus.adapters.myharness:MyHarness
+   proteus check --harness proteus.adapters.myharness:MyHarness --episode
+   ```
+
+4. **Gate it in CI.**
+   - If your adapter provisions **offline** (no Docker, no model, like `minimal`/`llm`),
+     add its name to `PURE_ADAPTERS` in
+     [`tests/test_conformance.py`](tests/test_conformance.py) (and
+     `OFFLINE_EPISODE_ADAPTERS` if its loop runs offline too). It's now checked on every
+     push.
+   - If it's **containerized or model-backed**, it can't run on stock CI. Validate it
+     locally through the same hook contributors use, and note in your PR that you ran it:
+
+     ```bash
+     PROTEUS_CHECK_ADAPTER=proteus.adapters.myharness:MyHarness \
+       PROTEUS_CHECK_EPISODE=1 pytest tests/test_conformance.py
+     ```
+
+5. **(Optional) register a short name** in `proteus/cli.py::_adapter_factory` so users can
+   write `--harness myharness` instead of the `module:Class` form.
+
+Prepared container images for a harness are a separate, optional step —
+`proteus env scaffold` / `proteus env build`; see [`docs/ADAPTERS.md`](docs/ADAPTERS.md)
+and [`environments/README.md`](environments/README.md).
+
+## Adding a benchmark
+
+A benchmark is a `BenchTask`: goal text, a `setup(ws)` that seeds the task workspace, and
+a `grade(ws)` that returns an `EvalResult`. See
+[`examples/benchmark_template.py`](examples/benchmark_template.py), the contract in
+[`proteus/bench/task.py`](proteus/bench/task.py), and the shipped
+[`proteus/bench/local.py`](proteus/bench/local.py) / `polyglot.py` / `swe.py`.
+
+1. **Scaffold:**
+
+   ```bash
+   python -m proteus.scaffold benchmark my_task      # -> proteus/bench/my_task.py
+   ```
+
+2. **Implement `setup` and `grade`.** The task workspace (`<run>/task/`) lives **outside**
+   the harness snapshot — it is the exercise, not the subject, and only moves forward.
+   Always degrade a broken/absent solution to a legible `0.0`, never raise: one bad
+   episode is a recorded zero, not a crashed sweep.
+
+   > **Security:** graders execute agent-authored code. Declare a `sandbox` parameter on
+   > `grade` and Proteus injects the episode's grader sandbox (`ctx.grader_sandbox`); run
+   > the agent's code through [`proteus/bench/sandbox.py`](proteus/bench/sandbox.py)
+   > (`run_python`), which never falls back to host Python — this is what `local.py` and
+   > `polyglot.py` do. A plain host `subprocess` is acceptable only for a trusted, local
+   > benchmark; see the note in `examples/benchmark_template.py`.
+
+3. **Wire and test.** `as_goal(TASK)` conditions a run on the task; `as_evaluator(TASK)`
+   scores without conditioning. Add a small grader test (solved → `1.0`, empty → `0.0`)
+   next to the ones in [`tests/test_conformance.py`](tests/test_conformance.py) /
+   `tests/test_bench.py`.
+
+## Pull requests
+
+- One adapter or one benchmark per PR keeps review tractable.
+- The three gate commands above must pass; say in the PR which heavy/opt-in checks you ran
+  locally (Docker adapters, SWE-bench) since CI can't.
+- New public behavior needs a test. New contract surface needs a line in the relevant doc
+  under `docs/`.

--- a/README.md
+++ b/README.md
@@ -216,6 +216,10 @@ proteus run   --harness mypkg.theirs_adapter:TheirsHarness --arm neutral ...
 
 `proteus check` machine-verifies the contract (removable disposition via fingerprint
 round-trip, snapshot-ability, trace shape). The full guide: [docs/ADAPTERS.md](docs/ADAPTERS.md).
+To start from a working skeleton instead of a blank file,
+`python -m proteus.scaffold adapter MyHarness` copies the fully-commented
+[examples/adapter_template.py](examples/adapter_template.py) — see
+[CONTRIBUTING.md](CONTRIBUTING.md).
 
 ## 📦 Prepared environments
 
@@ -279,6 +283,31 @@ pinned upstream versions, while the weekly upstream canary is advisory. As a
 cross-implementation check, Proteus's
 behavioural ruler applied to the research runs independently reproduces their headline
 dynamics: arms separate at episode 1 (R = 1.63) and converge by episode 30 (R = 0.93).
+
+## 🤝 Contributing
+
+The two highest-value contributions are **a new harness adapter** (evolve another agent
+framework) and **a new benchmark** (measure under more goals). Both are single-file,
+contract-checked, CI-gated additions:
+
+```bash
+python -m proteus.scaffold adapter MyHarness    # skeleton -> proteus/adapters/myharness.py
+python -m proteus.scaffold benchmark my_task    # skeleton -> proteus/bench/my_task.py
+proteus check --harness proteus.adapters.myharness:MyHarness --episode
+```
+
+The step-by-step guide (contract, templates, the conformance gate in
+`tests/test_conformance.py`, PR expectations) is [CONTRIBUTING.md](CONTRIBUTING.md).
+
+Where help is wanted, in one line each — the full list with difficulty tags is
+[ROADMAP.md](ROADMAP.md):
+
+- **More harnesses** — Hermes Agent first (Python, built-in self-improvement surfaces),
+  then SWE-agent, OpenClaw, Codex CLI, OpenHands, OpenCode, Goose.
+- **More benchmarks** — lightweight offline packs (HumanEval, MBPP, BigCodeBench-lite),
+  SWE-bench Lite/Verified wiring, and finishing sandboxed grading for `swe`.
+- **Analysis** — `proteus compare` for side-by-side arms/runs; an episode-atlas view.
+- **Reproducibility & cost** — per-episode token/cost accounting; one-command reproduce.
 
 ## 📖 Citation
 

--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -1,0 +1,77 @@
+# Proteus Roadmap
+
+Proteus measures how an agent harness changes itself. Growing it means growing two axes —
+**what can evolve** (harness adapters) and **what gets measured** (benchmarks) — plus the
+layer that makes results legible (analysis) and the plumbing that makes runs cheap to
+trust and reproduce.
+
+The contributor on-ramp for the first two is already in place: a checked `HarnessAdapter`
+contract, a `BenchTask` contract, copy-paste templates under `examples/`, a scaffolder
+(`python -m proteus.scaffold`), and a CI conformance gate (`tests/test_conformance.py`).
+Start at [`CONTRIBUTING.md`](CONTRIBUTING.md). Items below are tagged
+**[good first issue]**, **[medium]**, **[large]**.
+
+## T1 — More harnesses
+
+Each harness is one adapter (seven methods; see `CONTRIBUTING.md`). The framework's thesis
+is that the *harness's own source* is the thing that evolves, so the most valuable targets
+are ones whose source is tractable to rebuild from an episode's edits and that already
+expose named, self-editable surfaces. The framework now provides **staged activation**
+(`staged_activation = True` — an edit takes effect the next episode, gated by an optional
+`validate_candidate()`) and **framework continuity** (`continuity_mode = "framework"`), so
+a from-source coding harness that executes its own edits is well supported. Priority order:
+
+| Priority | Harness | Why | Fit |
+|---|---|---|---|
+| ★ first | **Hermes Agent** ([NousResearch](https://github.com/NousResearch/hermes-agent)) | Python, no build step (from-source is trivial), and a *built-in self-improvement loop* over named surfaces the agent already edits — skills, persistent memory, config, context files — plus recorded trajectories and session resets. The most on-thesis target available. | very high |
+| ★ | **SWE-agent** | pairs directly with the SWE-bench track (T2) | high |
+| ○ | **OpenClaw** ([openclaw](https://github.com/openclaw/openclaw)) | TS + `pnpm build` → the same containerized rebuild-from-source shape as the shipped `dsh`/`pi`; rich tools/skills/plugins surfaces (Plugin SDK, ClawHub). Its gateway/daemon means an episode drives one headless session. | medium-high |
+| ○ | **Codex CLI** ([openai/codex](https://github.com/openai/codex)) | Rust + Bazel → the same containerized rebuild-from-source shape as `dsh`/`pi`, but a heavier compile per boot; a natural `AGENTS.md` disposition-in-files channel plus `.codex` config. A coding-agent CLI, so it also pairs with the benchmark tracks. | medium |
+| ○ | **OpenHands** (ex-OpenDevin) | ships its own runtime/sandbox; large community | medium (heavy) |
+| ○ | **OpenCode**, **Goose** | broaden language/loop coverage | medium |
+
+- **[medium]** Add the **Hermes** adapter (recommended first harness): its skills/memory
+  surfaces map straight onto `surfaces()`, and no build step keeps `run_episode` simple.
+- **[large]** Add a containerized adapter (**OpenClaw** / **Codex CLI** / OpenHands)
+  following the `dsh`/`pi` rebuild-from-source + boot pattern, declaring
+  `staged_activation = True`. Codex's Rust/Bazel build is the heaviest per-boot cost of the
+  three — cache the compiled output on `/state` as `dsh`/`pi` do.
+- Proposing another harness? Open an issue describing its editable surfaces and how one
+  episode maps onto `run_episode`/`read_trace` before writing code.
+
+## T2 — More benchmarks
+
+Each benchmark is one `BenchTask` (`setup` + `grade`); see `CONTRIBUTING.md`.
+
+- **[good first issue]** Lightweight, offline-gradable packs, one `BenchTask` each:
+  HumanEval, MBPP, BigCodeBench (lite), a LiveCodeBench subset.
+- **[medium]** SWE-bench is already implemented (`proteus/bench/swe.py`) but heavy
+  (x86_64 + large disk). Make it usable: wire **SWE-bench Lite / Verified** subsets, and
+  degrade result-shape drift to a legible `0.0` instead of raising.
+- **[medium]** Finish routing grading through the episode sandbox. The plumbing exists
+  (`proteus/bench/sandbox.py::run_python`, injected via a `grade(..., sandbox=...)`
+  parameter) and `local`/`polyglot` already use it; migrate **`swe`** onto it and document
+  the `PROTEUS_GRADER_IMAGE` knob. (Grading agent-authored code on the host, outside the
+  episode's isolation, was a review finding — keep new benchmarks on the sandbox path.)
+
+## T3 — Output & analysis
+
+Live tracking already exists: `proteus watch` serves a self-contained `report.html`
+(per-run progress, per-surface growth curves, evaluator scores), and `web/server.py` is
+the hosted playground. The gap is **post-hoc, cross-run analysis** — `measure` /
+`reliability` / `audit` emit numbers, with no comparative view.
+
+- **[medium]** `proteus compare`: put several arms/runs side by side — structural and
+  behavioural measurements with effect sizes, confidence intervals, and crystallization
+  points — as one page or table.
+- **[large]** Generalize the one-off "atlas" (browse every episode's evolution path across
+  a whole grid) into a reusable view driven by any sweep's snapshot chain.
+
+## T5 — Reproducibility & cost
+
+- **[medium]** Per-episode token / cost accounting, surfaced in the run manifest and the
+  tracking page. The manifest already records the model per sweep; extend it to token and
+  cost counters — anyone running a grid needs them.
+- **[medium]** One-command reproduce: pin the environment image + config so a published
+  run can be re-executed, building on `proteus repo export` / `push` (which already turn a
+  run's snapshot chain into a normal git history).

--- a/examples/adapter_template.py
+++ b/examples/adapter_template.py
@@ -1,0 +1,205 @@
+"""Template: a new harness adapter, ready to copy.
+
+Copy this file to `proteus/adapters/<yourname>.py` (or scaffold it with
+`python -m proteus.scaffold adapter <YourName>`), then work through the TODOs. When it
+passes
+
+    proteus check --harness examples.adapter_template:TemplateHarness --episode
+
+your harness satisfies the whole `HarnessAdapter` contract and Proteus can evolve,
+measure, and swap dispositions in and out of it. Register a short name for it in
+`proteus/cli.py::_adapter_factory` if you want `--harness <shortname>` instead of the
+`<module>:<Class>` form.
+
+This template is intentionally offline and dependency-free (no model, no Docker) so it
+runs in tests and demos exactly like `proteus.adapters.minimal.MinimalHarness`, on which
+it is modelled. A real harness replaces `run_episode` with a call into its own agent loop
+(often inside a container — see `proteus.adapters.dsh`/`pi` for the from-source pattern),
+but every other method usually stays this small.
+
+The contract, in one breath: declare your editable **surfaces**, run **one episode** and
+emit a normalized **trace**, and **install/remove a disposition** so divergence and
+crystallization are measurable. Everything else (which model, how the loop is written) is
+your harness's business. See `proteus/core/adapter.py` for the authoritative types.
+"""
+
+from __future__ import annotations
+
+import hashlib
+import json
+import random
+from pathlib import Path
+from typing import Sequence
+
+from proteus.core.adapter import ActionEvent, EpisodeResult, EpisodeSpec, Surface
+from proteus.core.disposition import Disposition
+from proteus.core.episode import PHASES  # ("observe", "propose", "act", "reflect")
+
+
+class TemplateHarness:
+    """A `HarnessAdapter` skeleton. Rename the class and `name`, then fill the TODOs."""
+
+    #: Short, stable identifier for this harness. Appears in run manifests and reports.
+    name = "template"
+
+    #: How fresh phases continue across an episode. "none" (phases independent, like this
+    #: stub and `minimal`), "native" (your harness owns continuity — the default if you
+    #: omit this attribute entirely), or "framework" (let Proteus carry an external
+    #: handoff note between phases; framework adapters mount `.proteus-state` in the
+    #: container — see `proteus/core/continuity.py`). `proteus check` rejects any other value.
+    continuity_mode = "none"
+
+    #: Optional, for a harness whose OWN editable files can change how it executes (a
+    #: self-editing coding agent — the highest-value target). Declare `staged_activation
+    #: = True` and Proteus runs every phase from a frozen snapshot (`EpisodeSpec.active_root`)
+    #: while `root/harness` stays the writable candidate, so an edit only takes effect the
+    #: *next* episode and can be gated by an optional `validate_candidate(harness_root) -> str`.
+    #: Leave it off for a harness that does not execute its own edited files.
+    # staged_activation = True
+    # def validate_candidate(self, harness_root: Path) -> str: ...
+
+    #: True only if `install_disposition` writes the perturbation into a file the harness
+    #: reads on its own (an `AGENTS.md`-style instructions surface). Leave False and the
+    #: framework appends the disposition text to every phase prompt instead. Declaring
+    #: True when you also carry it in a file would double-dose the perturbation — read the
+    #: note on `HarnessAdapter.disposition_in_files` before flipping this.
+    disposition_in_files = False
+
+    # --- static declaration -------------------------------------------------------------
+    def surfaces(self) -> Sequence[Surface]:
+        """The persistent, agent-editable regions the measurement layer counts over.
+
+        TODO: declare one Surface per region your harness lets the agent edit. `unit` is
+        "file" | "directory" | "top_level_def"; set `is_code=True` for regions that must
+        still run after an edit (they pass the viability gate); `write_tools` names the
+        tool calls that count as edits to this surface.
+        """
+        return [
+            Surface("notes", "notes", unit="file",
+                    write_tools=frozenset({"write_note"})),
+        ]
+
+    def required_edit_tools(self) -> frozenset[str]:
+        """Tools whose presence proves the harness can still edit itself (viability)."""
+        return frozenset({"write_note"})
+
+    # --- provisioning -------------------------------------------------------------------
+    def seed(self, harness_root: Path, rng_seed: int = 0) -> None:
+        """Materialise a fresh copy of the harness at `harness_root` (episode-0 state).
+
+        TODO: lay down every surface directory and any baseline files the harness needs
+        to boot. For a from-source harness this is where you extract the real source from
+        the prepared image (see `dsh`/`pi`). `rng_seed` is the replicate index, for
+        harnesses that need deterministic per-seed naming at provisioning time.
+        """
+        (harness_root / "notes").mkdir(parents=True, exist_ok=True)
+        (harness_root / "STATE.md").write_text("# template harness\nepisode 0\n")
+
+    def install_disposition(self, harness_root: Path, disposition: Disposition) -> None:
+        """Apply the action-preference perturbation. MUST be removable.
+
+        Reinstalling `NEUTRAL` must restore the exact fingerprint you had before any
+        disposition was installed — `proteus check` enforces this, because
+        crystallization mounts the pre-perturbation state (F0). Here we serialise the
+        disposition to a dotfile; a file-carrying harness would instead write it into its
+        own instructions surface and set `disposition_in_files = True`.
+        """
+        (harness_root / ".disposition.json").write_text(json.dumps({
+            "label": disposition.label,
+            "config": dict(disposition.config),
+            "empty": disposition.is_empty,
+        }))
+
+    # --- run + observe ------------------------------------------------------------------
+    def run_episode(self, spec: EpisodeSpec) -> EpisodeResult:
+        """Run exactly one context-fresh episode against the harness at `spec.root`.
+
+        TODO: replace the deterministic stub below with a call into your agent loop. The
+        real work is: give the loop `spec.phase_prompts` (goal + evaluator feedback are
+        already merged in), let it edit the surfaces, and write a per-turn trace that
+        `read_trace` can reload. Results flow through the trace, never through stdout.
+
+        The writable harness is at `spec.root / "harness"`. If you declared
+        `staged_activation = True`, execute from `spec.active_root` instead and keep the
+        candidate separate. Turn budget: `spec.max_turns` bounds the episode;
+        `spec.min_turns_per_phase` reserves turns for later phases (a phase that reaches
+        its reserved line ends early — only a spent budget ends the episode). Honour it or
+        the mid-phase cap is untestable.
+        """
+        harness = spec.root / "harness"
+        (harness / "notes").mkdir(parents=True, exist_ok=True)  # restore may drop empty dirs
+        rng = random.Random(f"{spec.seed}:{spec.root.name}:{spec.episode}")
+        trace_path = spec.root / "traces" / f"ep{spec.episode:03d}.jsonl"
+        trace_path.parent.mkdir(parents=True, exist_ok=True)
+
+        turn = 0
+        writes = 0
+        capped = False
+        min_pp = int(getattr(spec, "min_turns_per_phase", 0) or 0)
+        with trace_path.open("w", encoding="utf-8") as sink:
+            for idx, phase in enumerate(PHASES):
+                if capped:
+                    break
+                stop_at = (spec.max_turns - min_pp * (len(PHASES) - idx - 1)
+                           if spec.max_turns else 0)
+                prompt = spec.phase_prompts.get(phase, "")
+                for tool, surface, text in self._stub_policy(phase, prompt, spec.episode, rng):
+                    if spec.max_turns and turn >= stop_at:
+                        capped = turn >= spec.max_turns
+                        break
+                    turn += 1
+                    if tool == "write_note":
+                        (harness / "notes" / f"{text}.md").write_text(
+                            f"episode {spec.episode}: {text}\n")
+                        writes += 1
+                    sink.write(json.dumps({
+                        "turn": turn, "phase": phase, "tool": tool,
+                        "surface": surface, "text": text,
+                    }) + "\n")
+        return EpisodeResult(episode=spec.episode, ok=True, turns=turn,
+                             counters={"writes": writes, "turn_capped": capped})
+
+    @staticmethod
+    def _stub_policy(phase: str, prompt: str, episode: int, rng: random.Random):
+        """Deterministic offline stand-in for a real agent loop. Delete when you wire yours."""
+        if phase == "observe":
+            return [("read_state", None, "surveyed the harness")]
+        if phase == "act":
+            return [("write_note", "notes", f"note_e{episode}_{rng.randint(0, 3)}")]
+        return []
+
+    def read_trace(self, root: Path, episode: int) -> Sequence[ActionEvent]:
+        """Reload one episode's trace as normalized `ActionEvent`s.
+
+        TODO: if your loop writes its own log format, translate it here. Phases must be
+        the canonical four (observe/propose/act/reflect); `tool=None` marks a text-only
+        turn; `surface` names the surface an edit targeted, when applicable.
+        """
+        path = root / "traces" / f"ep{episode:03d}.jsonl"
+        out: list[ActionEvent] = []
+        if not path.exists():
+            return out
+        for line in path.read_text(encoding="utf-8").splitlines():
+            if not line.strip():
+                continue
+            d = json.loads(line)
+            out.append(ActionEvent(turn=d["turn"], phase=d["phase"], tool=d.get("tool"),
+                                   surface=d.get("surface"), text=d.get("text", "")))
+        return out
+
+    # --- immutability observable --------------------------------------------------------
+    def disposition_fingerprint(self, harness_root: Path) -> str:
+        """A hash of the currently-installed disposition, to detect drift of F over time.
+
+        Must return the identical value before install and after removal (see
+        `install_disposition`).
+        """
+        p = harness_root / ".disposition.json"
+        return hashlib.sha256(p.read_bytes()).hexdigest() if p.exists() else ""
+
+
+if __name__ == "__main__":
+    # Smoke it exactly the way `proteus check` does, but inline and offline.
+    from proteus.testing import check_adapter
+
+    raise SystemExit(len(check_adapter(TemplateHarness(), episode=True)))

--- a/examples/benchmark_template.py
+++ b/examples/benchmark_template.py
@@ -1,0 +1,106 @@
+"""Template: a new benchmark, expressed as a `BenchTask`, ready to copy.
+
+A benchmark in Proteus is three things (see `proteus/bench/task.py`): the **goal text**
+the agent is given, a **setup** that seeds the task workspace, and a **grader** that reads
+the workspace afterwards and returns an `EvalResult`. Wrap it with `as_goal(task)` to hand
+to `RunConfig` (the agent works the task while its harness evolves), or `as_evaluator(task)`
+to score without conditioning. `proteus.bench.local` / `polyglot` / `swe` are the shipped
+instances; this is the smallest one that shows the whole shape.
+
+    python -m proteus.scaffold benchmark <yourname>   # copy + rename this file
+    python examples/benchmark_template.py             # run the demo below, offline
+
+The task workspace (`<run>/task/`) lives OUTSIDE the harness snapshot on purpose: it is
+the exercise, not the subject — it moves only forward, and selection rolls back the
+harness, never the task. Do not write task files into the harness root.
+
+SECURITY — graders execute agent-authored code. If `grade` declares a `sandbox`
+parameter, Proteus injects the episode's grader sandbox (`ctx.grader_sandbox`) and you run
+the agent's code under the same isolation as the episode via `proteus.bench.sandbox.run_python`
+— which never falls back to host Python. That is the production path (`proteus/bench/local.py`
+and `polyglot.py` both use it). The host-subprocess branch below runs only when no sandbox
+is supplied, so the template stays demonstrable offline; it is NOT isolation and must not
+be the path a real, self-editing harness is graded through.
+"""
+
+from __future__ import annotations
+
+import subprocess
+import sys
+import textwrap
+from pathlib import Path
+
+from proteus.bench.task import BenchTask
+from proteus.core.goal import EvalResult
+
+#: The checks the agent's solution must satisfy, as (call, expected) pairs. Keep them out
+#: of the workspace so the agent cannot read the answer key.
+_CHECKS = [("add(2, 3)", 5), ("add(-1, 1)", 0), ("add(0, 0)", 0)]
+
+GOAL_TEXT = textwrap.dedent("""\
+    In this workspace, edit `solution.py` so that it defines a function `add(a, b)`
+    returning the sum of its two arguments. Do not change anything else.
+""")
+
+
+def _probe_src() -> str:
+    """The verifier script: imports the agent's solution and asserts the hidden checks."""
+    return "import solution\n" + "".join(
+        f"assert solution.{call} == {expected}, {call!r}\n" for call, expected in _CHECKS)
+
+
+def _setup(ws: Path) -> None:
+    """Seed the task workspace: a spec, an empty stub, and a committed baseline for diffs.
+
+    TODO: for a real benchmark, clone/copy the instance's files here (SWE-bench clones a
+    repo at `base_commit`; the local pack copies a prompt + a held-out test it restores
+    before grading). Commit the seed so `workspace_diff` can show the agent's work.
+    """
+    (ws / "README.md").write_text(GOAL_TEXT)
+    (ws / "solution.py").write_text("# TODO: define add(a, b)\n")
+    subprocess.run(["git", "-C", str(ws), "init", "-q"], check=False)
+    subprocess.run(["git", "-C", str(ws), "add", "-A"], check=False, capture_output=True)
+    subprocess.run(["git", "-C", str(ws), "commit", "-q", "-m", "seed"],
+                   check=False, capture_output=True)
+
+
+def _grade(ws: Path, *, sandbox=None) -> EvalResult:
+    """Run the agent's solution against the hidden checks; score = fraction passed.
+
+    Declaring the `sandbox` parameter is what opts this grader into isolated execution:
+    `as_evaluator` sees it and passes `ctx.grader_sandbox`. Swap the checks below for your
+    benchmark's real verifier. Always degrade a broken/absent solution to a legible 0
+    rather than raising, so one bad episode is a recorded 0, not a crashed sweep.
+    """
+    if not (ws / "solution.py").exists():
+        return EvalResult(name="template-add", score=0.0, passed=False,
+                          detail="solution.py missing")
+    if sandbox is not None:
+        # Production path: execute the agent's code under the episode's isolation.
+        from proteus.bench.sandbox import run_python
+        (ws / "_probe.py").write_text(_probe_src())
+        proc = run_python(ws, "_probe.py", timeout_s=30, sandbox=sandbox)
+    else:
+        # Offline/demo fallback ONLY — the host process, i.e. no isolation. See the
+        # SECURITY note; a real harness is graded through the sandbox branch above.
+        proc = subprocess.run([sys.executable, "-c", _probe_src()], cwd=str(ws),
+                              capture_output=True, text=True, timeout=30)
+    if proc.returncode == 0:
+        return EvalResult(name="template-add", score=1.0, passed=True, detail="all checks pass")
+    return EvalResult(name="template-add", score=0.0, passed=False,
+                      detail=((proc.stderr or "").strip().splitlines() or ["failed"])[-1])
+
+
+#: The task object. `as_goal(TASK)` / `as_evaluator(TASK)` plug it into the framework.
+TASK = BenchTask(id="template-add", goal_text=GOAL_TEXT, setup=_setup, grade=_grade)
+
+
+if __name__ == "__main__":
+    import tempfile
+
+    with tempfile.TemporaryDirectory() as d:
+        ws = Path(d)
+        _setup(ws)
+        print("empty stub :", _grade(ws))                       # -> score 0.0
+        (ws / "solution.py").write_text("def add(a, b):\n    return a + b\n")
+        print("solved     :", _grade(ws))                       # -> score 1.0

--- a/proteus/scaffold.py
+++ b/proteus/scaffold.py
@@ -1,0 +1,112 @@
+"""Scaffold a new adapter or benchmark from the committed templates.
+
+    python -m proteus.scaffold adapter MyHarness           # -> proteus/adapters/myharness.py
+    python -m proteus.scaffold benchmark my_task           # -> proteus/bench/my_task.py
+    python -m proteus.scaffold adapter MyHarness --dest path/to/file.py
+
+The single source of truth for each skeleton is `examples/adapter_template.py` /
+`examples/benchmark_template.py` — this command copies one and renames the sentinel
+identifiers so `proteus check` (adapter) or the grader (benchmark) works immediately.
+Scaffolding is a source-checkout activity: the templates live under `examples/`, which is
+not shipped in the wheel, so run this from a clone (an editable `pip install -e .` is
+fine).
+"""
+
+from __future__ import annotations
+
+import argparse
+import re
+import sys
+from pathlib import Path
+
+
+def _repo_root() -> Path:
+    # proteus/ is a direct child of the repo root in a source checkout / editable install.
+    return Path(__file__).resolve().parent.parent
+
+
+def _dest_module(dest: Path) -> str:
+    """`proteus/adapters/foo.py` -> `proteus.adapters.foo`, relative to the repo root."""
+    try:
+        rel = dest.resolve().relative_to(_repo_root())
+    except ValueError:
+        return dest.stem  # dest is outside the repo; best we can offer is the module name
+    return ".".join(rel.with_suffix("").parts)
+
+
+def scaffold_adapter(name: str, dest: Path, *, force: bool = False) -> Path:
+    """Write a new adapter skeleton named `<name>Harness` to `dest`."""
+    cls = name if name.endswith("Harness") else f"{name}Harness"
+    short = re.sub(r"Harness$", "", cls)
+    short = re.sub(r"(?<!^)(?=[A-Z])", "_", short).lower()  # CamelCase -> snake_case
+    template = _repo_root() / "examples" / "adapter_template.py"
+    subs = {
+        "TemplateHarness": cls,
+        "examples.adapter_template": _dest_module(dest),
+        'name = "template"': f'name = "{short}"',
+    }
+    return _render(template, dest, subs, force=force)
+
+
+def scaffold_benchmark(name: str, dest: Path, *, force: bool = False) -> Path:
+    """Write a new benchmark (`BenchTask`) skeleton identified by `name` to `dest`."""
+    ident = re.sub(r"[^0-9a-zA-Z_-]", "-", name)
+    template = _repo_root() / "examples" / "benchmark_template.py"
+    subs = {
+        "examples.benchmark_template": _dest_module(dest),
+        '"template-add"': f'"{ident}"',
+        "name=\"template-add\"": f'name="{ident}"',
+    }
+    return _render(template, dest, subs, force=force)
+
+
+def _render(template: Path, dest: Path, subs: dict[str, str], *, force: bool) -> Path:
+    if not template.exists():
+        raise SystemExit(f"template not found: {template}\n"
+                         "run scaffold from a source checkout (see `pip install -e .`).")
+    if dest.exists() and not force:
+        raise SystemExit(f"{dest} already exists (use --force to overwrite)")
+    text = template.read_text(encoding="utf-8")
+    for old, new in subs.items():
+        text = text.replace(old, new)
+    dest.parent.mkdir(parents=True, exist_ok=True)
+    dest.write_text(text, encoding="utf-8")
+    return dest
+
+
+def main(argv: list[str] | None = None) -> int:
+    ap = argparse.ArgumentParser(prog="proteus.scaffold", description=__doc__,
+                                 formatter_class=argparse.RawDescriptionHelpFormatter)
+    sub = ap.add_subparsers(dest="kind", required=True)
+
+    a = sub.add_parser("adapter", help="new HarnessAdapter from examples/adapter_template.py")
+    a.add_argument("name", help="class name, e.g. MyHarness (the 'Harness' suffix is optional)")
+    a.add_argument("--dest", default="", help="output path (default: proteus/adapters/<name>.py)")
+    a.add_argument("--force", action="store_true", help="overwrite an existing file")
+
+    b = sub.add_parser("benchmark", help="new BenchTask from examples/benchmark_template.py")
+    b.add_argument("name", help="benchmark id, e.g. my_task")
+    b.add_argument("--dest", default="", help="output path (default: proteus/bench/<name>.py)")
+    b.add_argument("--force", action="store_true", help="overwrite an existing file")
+
+    args = ap.parse_args(argv)
+
+    if args.kind == "adapter":
+        short = re.sub(r"Harness$", "", args.name)
+        short = re.sub(r"(?<!^)(?=[A-Z])", "_", short).lower()
+        dest = Path(args.dest) if args.dest else _repo_root() / "proteus" / "adapters" / f"{short}.py"
+        out = scaffold_adapter(args.name, dest, force=args.force)
+        mod = _dest_module(out)
+        cls = args.name if args.name.endswith("Harness") else args.name + "Harness"
+        print(f"scaffolded {out}")
+        print(f"next: implement the TODOs, then  proteus check --harness {mod}:{cls} --episode")
+    else:
+        dest = Path(args.dest) if args.dest else _repo_root() / "proteus" / "bench" / f"{args.name}.py"
+        out = scaffold_benchmark(args.name, dest, force=args.force)
+        print(f"scaffolded {out}")
+        print("next: implement setup()/grade(), then wire TASK into a run via as_goal(TASK)")
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/tests/test_conformance.py
+++ b/tests/test_conformance.py
@@ -1,0 +1,136 @@
+"""The public adapter/benchmark conformance gate.
+
+Every built-in adapter that runs without Docker or a model is checked here against the
+whole `HarnessAdapter` contract (`proteus.testing.check_adapter`), so a change that
+breaks the contract fails CI. The committed templates and the scaffolder are checked the
+same way, so `examples/adapter_template.py` and `python -m proteus.scaffold` can never
+silently rot.
+
+Contributors: this is the suite to point at your own adapter. Either register it in
+`proteus/cli.py::_adapter_factory` and add its name to `PURE_ADAPTERS` (if it runs
+offline), or, for a containerized / model-backed harness, run the opt-in hook:
+
+    PROTEUS_CHECK_ADAPTER=mypkg.mod:MyHarness pytest tests/test_conformance.py
+    PROTEUS_CHECK_ADAPTER=pi PROTEUS_CHECK_EPISODE=1 pytest tests/test_conformance.py
+
+The same hook validates the built-in heavy adapters (dsh, pi, aki) on a machine that has
+Docker / their checkouts; they are not in the default gate because CI has neither.
+"""
+
+from __future__ import annotations
+
+import importlib
+import importlib.util
+import os
+import sys
+from pathlib import Path
+
+import pytest
+
+_REPO_ROOT = Path(__file__).resolve().parent.parent
+if str(_REPO_ROOT) not in sys.path:
+    sys.path.insert(0, str(_REPO_ROOT))  # make the un-installed examples/ importable
+
+from proteus.testing import check_adapter  # noqa: E402
+
+
+def _load(name: str):
+    """Resolve an adapter class the same way the CLI does (`--harness`)."""
+    from proteus.cli import _adapter_factory
+    return _adapter_factory(name)
+
+
+# Adapters that provision offline (no Docker, no model): the always-on CI gate. Names
+# resolve through the same factory `proteus check --harness` uses.
+PURE_ADAPTERS = ["minimal", "llm", "examples.adapter_template:TemplateHarness"]
+
+# Of those, the ones whose loop also runs a full episode offline (so `--episode` works
+# with no API key). `llm` needs a model, so it is provisioning-only above.
+OFFLINE_EPISODE_ADAPTERS = ["minimal", "examples.adapter_template:TemplateHarness"]
+
+
+@pytest.mark.parametrize("name", PURE_ADAPTERS)
+def test_pure_adapter_conformance(name):
+    failures = check_adapter(_load(name)(), episode=False, verbose=False)
+    assert failures == [], f"{name} fails the contract: {failures}"
+
+
+@pytest.mark.parametrize("name", OFFLINE_EPISODE_ADAPTERS)
+def test_offline_episode_conformance(name):
+    failures = check_adapter(_load(name)(), episode=True, verbose=False)
+    assert failures == [], f"{name} fails the live-episode contract: {failures}"
+
+
+# --- benchmark contract -----------------------------------------------------------------
+
+def _bench_template():
+    return importlib.import_module("examples.benchmark_template")
+
+
+def test_benchmark_template_grades():
+    bt = _bench_template()
+    import tempfile
+    with tempfile.TemporaryDirectory() as d:
+        ws = Path(d)
+        bt.TASK.setup(ws)
+        empty = bt.TASK.grade(ws)
+        assert empty.score == 0.0 and not empty.passed
+        (ws / "solution.py").write_text("def add(a, b):\n    return a + b\n")
+        solved = bt.TASK.grade(ws)
+        assert solved.score == 1.0 and solved.passed
+
+
+def test_benchmark_wiring():
+    """A BenchTask plugs into both the evaluator and the goal paths."""
+    from proteus.bench.task import as_evaluator, as_goal, seed_task
+    from proteus.core.goal import GoalConfig, GoalContext
+    bt = _bench_template()
+    import tempfile
+    with tempfile.TemporaryDirectory() as d:
+        harness = Path(d) / "harness"
+        harness.mkdir(parents=True)
+        seed_task(harness, bt.TASK)                       # materialises <run>/task/
+        ev = as_evaluator(bt.TASK)
+        res = ev([], GoalContext(harness_root=str(harness), episode=1))
+        assert res.name == bt.TASK.id and 0.0 <= res.score <= 1.0
+        assert isinstance(as_goal(bt.TASK), GoalConfig)
+
+
+# --- scaffolder round-trips (the templates and the generator cannot rot) -----------------
+
+def _import_file(path: Path, mod_name: str):
+    spec = importlib.util.spec_from_file_location(mod_name, path)
+    mod = importlib.util.module_from_spec(spec)
+    spec.loader.exec_module(mod)
+    return mod
+
+
+def test_scaffold_adapter_roundtrip(tmp_path):
+    from proteus.scaffold import scaffold_adapter
+    dest = tmp_path / "myharness.py"
+    scaffold_adapter("MyHarness", dest)
+    mod = _import_file(dest, "scaffolded_adapter")
+    cls = mod.MyHarness
+    assert cls.name == "my"
+    assert check_adapter(cls(), episode=True, verbose=False) == []
+
+
+def test_scaffold_benchmark_roundtrip(tmp_path):
+    from proteus.bench.task import BenchTask
+    from proteus.scaffold import scaffold_benchmark
+    dest = tmp_path / "my_task.py"
+    scaffold_benchmark("my_task", dest)
+    mod = _import_file(dest, "scaffolded_bench")
+    assert isinstance(mod.TASK, BenchTask)
+    assert mod.TASK.id == "my_task"
+
+
+# --- opt-in hook for containerized / third-party adapters -------------------------------
+
+@pytest.mark.skipif(not os.environ.get("PROTEUS_CHECK_ADAPTER"),
+                    reason="set PROTEUS_CHECK_ADAPTER=<name|module:Class> to check one")
+def test_registered_adapter_conformance():
+    name = os.environ["PROTEUS_CHECK_ADAPTER"]
+    episode = bool(os.environ.get("PROTEUS_CHECK_EPISODE"))
+    failures = check_adapter(_load(name)(), episode=episode, verbose=False)
+    assert failures == [], f"{name} fails the contract: {failures}"


### PR DESCRIPTION
## What

Makes a new **harness adapter** or **benchmark** a single-file, contract-checked, CI-gated addition — the T4 contributor infrastructure. No changes to existing runtime behavior; all additions.

- **`tests/test_conformance.py`** — parametrized `HarnessAdapter` conformance (`proteus.testing.check_adapter`) over the offline built-ins (`minimal`, `llm`) + the template, plus scaffolder round-trips and `BenchTask` wiring. A `PROTEUS_CHECK_ADAPTER=<name|module:Class>` hook validates containerized/third-party adapters (and the built-in `dsh`/`pi`/`aki`) on a machine that has Docker/checkouts. Runs on every push via `pytest tests/`.
- **`examples/adapter_template.py`** — a `proteus check`-passing skeleton, including the optional `continuity_mode` / `staged_activation` surface for from-source coding harnesses.
- **`examples/benchmark_template.py`** — a `BenchTask` that grades through the injected grader sandbox (`proteus.bench.sandbox.run_python`), with an offline host fallback for the demo/test path.
- **`proteus/scaffold.py`** — `python -m proteus.scaffold adapter|benchmark <name>`, rendered from the templates (single source of truth).
- **`CONTRIBUTING.md`**, **`ROADMAP.md`** — the on-ramp guide and the T1 (harnesses) / T2 (benchmarks) / T3 (analysis) / T5 (repro) roadmap.

## Gate (this branch, Python 3.10.13)

- `ruff check .` → clean
- `pytest tests/ -q` → **109 passed, 1 skipped** (the skip is the opt-in `PROTEUS_CHECK_ADAPTER` hook)
- `python tests/run_offline.py` → 94 passed

🤖 Generated with [Claude Code](https://claude.com/claude-code)