### PR TITLE
release: prepare Proteus v0.2.0

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -29,3 +29,31 @@ jobs:
         run: pytest tests/ -q
       - name: offline runner (the no-pytest path must stay alive)
         run: python tests/run_offline.py
+
+  distribution:
+    name: Installed wheel and sdist
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-python@v5
+        with:
+          python-version: "3.12"
+      - run: python -m pip install --disable-pip-version-check build==1.3.0
+      - run: python -m build
+      - name: Wheel scaffolder works outside the checkout
+        run: |
+          python -m venv /tmp/proteus-wheel
+          /tmp/proteus-wheel/bin/pip install --disable-pip-version-check --no-deps dist/*.whl
+          mkdir /tmp/proteus-wheel-out
+          cd /tmp/proteus-wheel-out
+          /tmp/proteus-wheel/bin/python -c 'import importlib.metadata, proteus; assert importlib.metadata.version("proteus-evolve") == proteus.__version__'
+          /tmp/proteus-wheel/bin/python -m proteus.scaffold adapter WheelHarness
+          /tmp/proteus-wheel/bin/proteus check --harness wheel:WheelHarness --episode
+      - name: Sdist scaffolder works outside the checkout
+        run: |
+          python -m venv /tmp/proteus-sdist
+          /tmp/proteus-sdist/bin/pip install --disable-pip-version-check --no-deps dist/*.tar.gz
+          mkdir /tmp/proteus-sdist-out
+          cd /tmp/proteus-sdist-out
+          /tmp/proteus-sdist/bin/python -m proteus.scaffold benchmark package_task
+          /tmp/proteus-sdist/bin/python -c 'import package_task; assert package_task.TASK.id == "package_task"'

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -24,20 +24,34 @@ jobs:
         run: |
           python - <<'PY'
           import os
-          import tomllib
+          from proteus import __version__ as version
 
-          with open("pyproject.toml", "rb") as source:
-              version = tomllib.load(source)["project"]["version"]
           expected = f"v{version}"
           actual = os.environ["RELEASE_TAG"]
           if actual != expected:
-              raise SystemExit(f"release tag {actual!r} does not match package {expected!r}")
+              raise SystemExit(f"release tag {actual!r} does not match runtime {expected!r}")
           PY
       - name: Build sdist and wheel
         run: |
           python -m pip install --disable-pip-version-check build==1.3.0 twine==6.2.0
           python -m build
           python -m twine check dist/*
+      - name: Smoke-test the installed wheel and sdist
+        run: |
+          python -m venv /tmp/proteus-wheel
+          /tmp/proteus-wheel/bin/pip install --disable-pip-version-check --no-deps dist/*.whl
+          mkdir /tmp/proteus-wheel-out
+          cd /tmp/proteus-wheel-out
+          /tmp/proteus-wheel/bin/python -c 'import importlib.metadata, proteus; assert importlib.metadata.version("proteus-evolve") == proteus.__version__'
+          /tmp/proteus-wheel/bin/python -m proteus.scaffold adapter WheelHarness
+          /tmp/proteus-wheel/bin/proteus check --harness wheel:WheelHarness --episode
+
+          python -m venv /tmp/proteus-sdist
+          /tmp/proteus-sdist/bin/pip install --disable-pip-version-check --no-deps "$GITHUB_WORKSPACE"/dist/*.tar.gz
+          mkdir /tmp/proteus-sdist-out
+          cd /tmp/proteus-sdist-out
+          /tmp/proteus-sdist/bin/python -m proteus.scaffold benchmark package_task
+          /tmp/proteus-sdist/bin/python -c 'import package_task; assert package_task.TASK.id == "package_task"'
       - name: Store release distributions
         uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4
         with:

--- a/README.md
+++ b/README.md
@@ -13,7 +13,7 @@
   <a href="https://github.com/proteus-evolve/Proteus/actions/workflows/release-smoke.yml"><img src="https://github.com/proteus-evolve/Proteus/actions/workflows/release-smoke.yml/badge.svg" alt="release smoke"></a>
   <a href="LICENSE"><img src="https://img.shields.io/badge/license-MIT-green.svg" alt="MIT License"></a>
   <img src="https://img.shields.io/badge/python-3.10%2B-blue.svg" alt="Python 3.10+">
-  <img src="https://img.shields.io/badge/version-0.1.0-informational.svg" alt="v0.1.0">
+  <img src="https://img.shields.io/badge/version-0.2.0-informational.svg" alt="v0.2.0">
   <img src="https://img.shields.io/badge/status-research%20preview-orange.svg" alt="research preview">
 </p>
 
@@ -26,6 +26,7 @@
   <a href="docs/RECIPES.md">Recipes</a> •
   <a href="docs/BENCHMARKS.md">Bring a Benchmark</a> •
   <a href="docs/MEASUREMENTS.md">Add a Measurement</a> •
+  <a href="docs/releases/v0.2.0.md">v0.2.0 Notes</a> •
   <a href="environments/README.md">Environments</a> •
   <a href="#-measurement">Measurement</a>
 </p>
@@ -219,7 +220,8 @@ round-trip, snapshot-ability, trace shape). The full guide: [docs/ADAPTERS.md](d
 To start from a working skeleton instead of a blank file,
 `python -m proteus.scaffold adapter MyHarness` copies the fully-commented
 [examples/adapter_template.py](examples/adapter_template.py) — see
-[CONTRIBUTING.md](CONTRIBUTING.md).
+[CONTRIBUTING.md](CONTRIBUTING.md). The templates ship on PyPI too; outside a Git checkout
+the default output is the current directory (or choose an explicit `--dest`).
 
 ## 📦 Prepared environments
 
@@ -270,7 +272,7 @@ roots, so the evolving agent can never read its own condition.
 
 ## 📊 Status
 
-`v0.1` (research preview). Working today: the offline `minimal` harness; the live `llm`
+`v0.2.0` (research preview). Working today: the offline `minimal` harness; the live `llm`
 harness; pinned, source-evolving DeepSeek Harness and Pi adapters with frozen per-episode
 activation, automatic rollback, exact-tree boundary gates, rebuild caching, turn budgets,
 and task mounts; the Aki research adapter;

--- a/docs/ADAPTERS.md
+++ b/docs/ADAPTERS.md
@@ -216,11 +216,13 @@ isolation runs during.
 ## Resuming an interrupted seed
 
 Episodes cost minutes to tens of minutes, so a seed that dies at episode 26 is hours of
-trajectory. `run(cfg, start=N)` continues from the episode after `N`, using the harness on
-disk rather than re-seeding over it, and `proteus run --on-existing resume` does this for a
-whole sweep: finished seeds are skipped, partial ones pick up at the episode after their
-last snapshot. `completed_episodes()` counts contiguous snapshot commits, not trace files —
-a provider outage writes a trace per failed attempt, and counting those reports a seed that
+trajectory. `run(cfg, start=N, resume=True)` continues from the episode after `N`, using
+the harness on disk rather than re-seeding over it; a positive `start` implies resume, while
+the explicit flag distinguishes episode-0 recovery from a new run. `proteus run
+--on-existing resume` applies this to a whole sweep only after the versioned manifest
+condition matches: finished seeds are skipped, partial ones pick up after their last
+snapshot. `completed_episodes()` counts contiguous snapshot commits, not trace files — a
+provider outage writes a trace per failed attempt, and counting those reports a seed that
 finished nothing as complete.
 
 ## Letting the harness edit its own code

--- a/docs/EPISODE.md
+++ b/docs/EPISODE.md
@@ -24,12 +24,15 @@ are identical.
 | 3. task seeding (benchmark runs only) | framework | `seed_task` writes the benchmark task into `<run>/task/`, beside the harness and outside its snapshot; dsh/pi mount it at `/workspace/task` |
 | 4. `snapshot.init(harness)` | framework | bare git repo; **every ignore rule disabled** (the harness is the measured object — nothing in it may be invisible to the instrument); commit `episode 0` |
 
-Resume (`run(cfg, start=N)`) skips all four and continues on the evolved harness on
-disk from episode N+1. `completed_episodes` counts **contiguous snapshot commits**, not
-trace files — a provider outage writes a trace per failed attempt. Before any resume,
-Proteus restores files, index, and HEAD to the exact episode-N checkpoint. This removes a
-half-written candidate left by SIGKILL or a machine restart before it can leak into the
-next attempt.
+Resume (`run(cfg, start=N, resume=True)`) skips all four and continues on the evolved
+harness on disk from episode N+1. Positive `start` values imply resume for API
+compatibility; the explicit flag matters at N=0, where a new run and a crashed-before-
+episode-1 run otherwise look identical. `completed_episodes` counts **contiguous snapshot
+commits**, not trace files — a provider outage writes a trace per failed attempt. Before
+any resume, Proteus restores files, index, and HEAD to the exact episode-N checkpoint
+(including episode 0), reconciles the framework handoff, and verifies private records.
+This removes a half-written candidate left by SIGKILL or a machine restart before it can
+leak into the next attempt.
 
 ## Every episode N
 
@@ -214,6 +217,12 @@ Both evaluator history and the initial/candidate/checkpoint disposition fingerpr
 under the sibling `.proteus-records/<run-id>/`, never inside the subject-visible run root.
 Resume requires the snapshot count, history rows, continuity checkpoint, and current
 fingerprint to agree with the last durable checkpoint.
+
+At sweep level, `manifest.json` carries a versioned immutable `condition` record: adapter
+identity/runtime knobs, surfaces, disposition fingerprints, model, goal, evaluators, task,
+budgets, continuity, and caller-supplied non-secret metadata. `--on-existing resume`
+compares it before touching the run; `refuse` also checks before writing anything. A v0.1
+manifest has no condition lock and is deliberately not resumable under v0.2.
 
 ### 10. Next episode — framework
 

--- a/docs/MEASUREMENTS.md
+++ b/docs/MEASUREMENTS.md
@@ -23,7 +23,7 @@ For a sweep rooted at `runs/demo/`:
 
 ```text
 runs/demo/
-├── manifest.json                  # planned arms, seeds, goal, evaluator metadata
+├── manifest.json                  # plan + immutable, versioned experimental condition
 ├── seeds.jsonl                    # one completion record per run attempt
 ├── progress/<run-id>.jsonl        # live per-episode units, scores, counters
 └── runs/

--- a/docs/RECIPES.md
+++ b/docs/RECIPES.md
@@ -122,8 +122,13 @@ git -C dsh-evolution log --oneline
 ```
 
 The resume invocation must use the same experimental configuration as the original run.
-Resume restores the evolved files, selection baseline, visible feedback, and cumulative
-counters; it does not reseed the harness.
+Proteus v0.2 records that condition in `manifest.json` and rejects model, goal, evaluator,
+arm, task, budget, adapter/environment, or continuity changes **before modifying any run
+record**. Resume restores the evolved files, selection baseline, visible feedback,
+cumulative counters, and framework handoff; it does not reseed the harness. This includes
+a crash before episode 1: the episode-0 checkpoint is restored rather than treated as a
+fresh run. A v0.1 sweep cannot be condition-verified and must be finished with v0.1 or
+restarted under a new `--out` (see the v0.2.0 release notes).
 
 ## A benchmark as the goal
 

--- a/docs/RELEASING.md
+++ b/docs/RELEASING.md
@@ -23,7 +23,9 @@ reserve the name before that upload.
 ## Release checklist
 
 1. Confirm `main` is clean, pushed, and green in `.github/workflows/ci.yml`.
-2. Set `project.version` in `pyproject.toml`; update user-facing version/install text.
+2. Set the single version source, `proteus.__version__`, in `proteus/__init__.py`; update
+   the README badge, install text, and `docs/releases/v<version>.md`. `pyproject.toml`
+   reads this value dynamically, and CI verifies installed metadata matches it.
 3. Build locally and validate both distributions:
 
    ```bash
@@ -31,18 +33,22 @@ reserve the name before that upload.
    python -m twine check dist/*
    ```
 
-4. Push the annotated release tag. The tag automatically starts `release-smoke`:
+4. Smoke-test both installed distributions outside the checkout. This is also enforced in
+   CI and the publishing workflow: the scaffolder must generate a working adapter from the
+   wheel and a working benchmark from the sdist.
+5. Push the annotated release tag. The tag automatically starts `release-smoke`:
 
    ```bash
-   git tag -a v0.1.0 -m "Proteus v0.1.0"
-   git push origin v0.1.0
+   VERSION=0.2.0
+   git tag -a "v$VERSION" -m "Proteus v$VERSION"
+   git push origin "v$VERSION"
    ```
 
-5. Do not create the GitHub Release until every `release-smoke` job for that tag passes.
-6. Publish the GitHub Release from the same tag. `.github/workflows/publish.yml` verifies
-   that the tag matches `project.version`, builds an sdist and wheel in a non-publishing
+6. Do not create the GitHub Release until every `release-smoke` job for that tag passes.
+7. Publish the GitHub Release from the same tag. `.github/workflows/publish.yml` verifies
+   that the tag matches `proteus.__version__`, builds an sdist and wheel in a non-publishing
    job, then uploads them through the protected `pypi` environment using OIDC.
-7. Verify `pip install proteus-evolve==<version>` in a fresh environment and check the
+8. Verify `pip install proteus-evolve==<version>` in a fresh environment and check the
    PyPI provenance/attestation before announcing the release.
 
 PyPI files and versions cannot be replaced. If upload verification fails after a version

--- a/docs/releases/v0.2.0.md
+++ b/docs/releases/v0.2.0.md
@@ -1,0 +1,76 @@
+# Proteus v0.2.0
+
+Proteus v0.2.0 makes an evolution episode a recoverable transaction and turns harness /
+benchmark onboarding into a tested public contract. It is the first release in which the
+real source of DSH and Pi can evolve behind a frozen runtime boundary: a candidate may be
+inspected during the episode, but it cannot control the harness until the next episode and
+only after its normal build/boot path succeeds.
+
+## Highlights
+
+### Transactional self-evolution
+
+- DSH and Pi execute every phase of episode N from one read-only, last-valid snapshot.
+  Persistent edits go to a separate candidate and activate no earlier than episode N+1.
+- The episode-boundary viability gate rebuilds and boots self-edited source before an
+  evaluator can execute it. Invalid candidates are retained as inspectable candidate
+  commits, scored as rejected episodes, and automatically rolled back.
+- Adapter/provider/snapshot failures preserve each failed attempt without advancing the
+  episode number. Resume restores files, the Git index, HEAD, evaluator state, selection
+  baseline, disposition fingerprint, and framework handoff to the last durable checkpoint.
+- Episode-0 recovery is explicit: a process killed before its first completed episode can
+  no longer leak a half-written candidate into episode 1.
+
+### Context-fresh continuity
+
+- Harnesses may opt into the generic Proteus handoff protocol. Each phase starts with a
+  fresh model context and receives a bounded operational handoff containing findings,
+  files, tests, open questions, and next action.
+- Handoffs live outside the measured harness snapshot. Secret-like values are redacted,
+  raw reasoning/tool output is never copied, and interrupted phases fall back to normalized
+  tool names and paths.
+
+### Reproducible runs and safer benchmarks
+
+- Sweep manifests now carry a versioned, immutable experimental condition: adapter and
+  surfaces, dispositions, model, goal, evaluator metadata, task, budgets, continuity, and
+  non-secret caller metadata. `resume` rejects any mismatch before modifying run records.
+- `refuse` is now observationally read-only; even an accidental second invocation cannot
+  overwrite the original manifest.
+- Local and Polyglot benchmark code runs in a networkless, resource-limited Docker grader;
+  unavailable isolation becomes a scored failure and never falls back to host execution.
+- Manifests record the selected model, seed records are atomically updated, and resume
+  preserves evaluator history and cumulative counters.
+
+### Contributor on-ramp
+
+- `HarnessAdapter` and `BenchTask` receive fully commented templates, a scaffolder, a
+  conformance checker, and a CI gate.
+- `python -m proteus.scaffold adapter MyHarness` and `benchmark my_task` now work from an
+  installed wheel or sdist as well as a Git checkout.
+- New guides cover adding harnesses, benchmarks, and measurements, plus prepared
+  environment construction and the generic episode contract.
+
+## Compatibility and migration
+
+- **Do not resume a v0.1.x sweep with v0.2.0.** v0.2 moves hidden evaluator records out of
+  the subject-visible run root and introduces a condition-locked manifest. Because a v0.1
+  manifest cannot prove that the resumed configuration is identical, v0.2 refuses it
+  instead of risking a mixed-condition trajectory. Finish the run with v0.1.x, or start a
+  new `--out`. `--on-existing overwrite` is available after backing up the old sweep and
+  intentionally removes the complete previous sweep state.
+- Custom source-evolving adapters should declare `staged_activation = True` and implement
+  `validate_candidate()` if edited files can affect their own runtime. Existing adapters
+  without the attribute retain native activation behavior.
+- Framework-continuity adapters mount the handoff at `/workspace/.proteus/handoff.md`;
+  their writable staged candidate is `/workspace/candidate`.
+
+## Install
+
+```bash
+python -m pip install --upgrade proteus-evolve==0.2.0
+```
+
+Proteus remains a research preview and requires Python 3.10+. The v0.2.0 release gate
+uses the pinned DSH `dsh-v0.1.0-rc.7` and Pi `v0.84.2` source environments so published
+results remain reproducible; the separate upstream canary tracks newer upstream versions.

--- a/examples/__init__.py
+++ b/examples/__init__.py
@@ -1,0 +1,6 @@
+"""Shipped contributor templates and runnable Proteus examples.
+
+The package marker is intentional: setuptools includes this directory in both the wheel
+and source distribution, so ``python -m proteus.scaffold`` has the same templates after a
+PyPI install as it does in a Git checkout.
+"""

--- a/proteus/__init__.py
+++ b/proteus/__init__.py
@@ -1,2 +1,2 @@
 """Proteus — a harness-agnostic framework for agent self-evolution."""
-__version__ = "0.1.0"
+__version__ = "0.2.0"

--- a/proteus/cli.py
+++ b/proteus/cli.py
@@ -57,10 +57,21 @@ def _adapter_factory(name: str):
         # your own adapter, no registration needed: --harness mypkg.mymodule:MyHarness
         import importlib
         mod_name, _, cls_name = name.partition(":")
+        # A generated adapter is commonly an uninstalled module in the current project.
+        # Python adds that directory for ``python -m ...`` but not for a console-script
+        # entry point such as ``proteus``.  Put it first just for this import so the
+        # scaffolder's printed next command also works from a regular wheel install.
+        cwd = str(Path.cwd())
+        sys.path.insert(0, cwd)
         try:
             cls = getattr(importlib.import_module(mod_name), cls_name)
         except (ImportError, AttributeError) as exc:
             raise SystemExit(f"cannot load harness {name!r}: {exc}") from exc
+        finally:
+            try:
+                sys.path.remove(cwd)
+            except ValueError:  # pragma: no cover - defensive against import hooks
+                pass
         return cls
     raise SystemExit(f"unknown harness {name!r} "
                      "(built-in: minimal, llm, dsh, pi, aki; or use <module>:<Class>)")
@@ -189,6 +200,8 @@ def _evaluator(spec: str, adapter_factory):
 
 
 def cmd_run(args) -> int:
+    import hashlib
+
     if args.max_turns < 0:
         raise SystemExit("--max-turns must be 0 (unlimited) or a positive integer")
     if args.min_turns_per_phase < 0:
@@ -218,13 +231,22 @@ def cmd_run(args) -> int:
         episodes=args.episodes,
         max_turns=args.max_turns,
         task=(tasks[0] if tasks else None),
+        condition_metadata={
+            # A contains:<path>:<needle> evaluator may embed sensitive literal text.
+            # The normal manifest rows already expose its public identity; digests keep
+            # resume sensitive to every raw CLI parameter without publishing the needle.
+            "evaluator_specs": [
+                hashlib.sha256(spec.encode()).hexdigest()
+                for spec in (args.evaluator or ())
+            ],
+        },
         min_turns_per_phase=args.min_turns_per_phase,
         announce_budget=args.announce_budget,
         on_existing=args.on_existing,
     )
     try:
         records = run_sweep(cfg)
-    except FileExistsError as exc:
+    except (FileExistsError, ValueError) as exc:
         raise SystemExit(str(exc)) from None
     done = sum(r["episodes_complete"] for r in records)
     print(f"ran {len(records)} seeds, {done} episodes -> {args.out}")

--- a/proteus/core/episode.py
+++ b/proteus/core/episode.py
@@ -206,14 +206,16 @@ def completed_episodes(cfg: RunConfig) -> int:
     return ep
 
 
-def run(cfg: RunConfig, start: int = 0) -> RunResult:
+def run(cfg: RunConfig, start: int = 0, *, resume: bool = False) -> RunResult:
     """Run one seed's full trajectory, harness retained under `cfg.root`.
 
     `start` resumes an interrupted seed: episodes up to and including `start` are taken as
-    done and the harness on disk is used as-is. Re-seeding a resumed root would overwrite
-    the evolved harness with fresh templates, so provisioning is skipped entirely — at
-    tens of minutes per episode, restarting a seed that died at episode 26 throws away
-    real trajectory, which is why this exists.
+    done and the harness on disk is used as-is. `resume=True` is required to distinguish
+    recovery from episode 0 from a genuinely fresh run — both have `start == 0`, but only
+    the former already has a snapshot that must be restored before retrying episode 1.
+    Any positive `start` implies resume for backward compatibility. Re-seeding a resumed
+    root would overwrite the evolved harness with fresh templates, so provisioning is
+    skipped entirely.
     """
     harness = cfg.root / "harness"
     if cfg.max_turns and cfg.min_turns_per_phase * len(PHASES) > cfg.max_turns:
@@ -222,7 +224,8 @@ def run(cfg: RunConfig, start: int = 0) -> RunResult:
             f"{cfg.min_turns_per_phase}: {len(PHASES)} phases need at least "
             f"{cfg.min_turns_per_phase * len(PHASES)} turns")
     completed = completed_episodes(cfg)
-    if start:
+    is_resume = resume or bool(start)
+    if is_resume:
         if completed != start:
             raise ValueError(
                 f"cannot resume {cfg.root} at episode {start}: snapshot history has "
@@ -260,19 +263,20 @@ def run(cfg: RunConfig, start: int = 0) -> RunResult:
     history_path = eval_history_path(cfg.root)
     fingerprint_path = records / "disposition_fingerprint.json"
     fingerprint = cfg.adapter.disposition_fingerprint(harness)
-    if not start:
+    if not is_resume:
         _write_json_atomic(fingerprint_path, {"fingerprint": fingerprint})
-    if start:
-        if not history_path.exists():
+    if is_resume:
+        if start and not history_path.exists():
             raise ValueError(
                 f"cannot resume {cfg.root}: {start} episodes are snapshotted but "
                 f"private eval history is missing at {history_path}")
-        try:
-            eval_history = json.loads(history_path.read_text(encoding="utf-8"))
-        except (json.JSONDecodeError, OSError) as exc:
-            raise ValueError(
-                f"cannot resume {cfg.root}: private eval history is unreadable: {exc}"
-            ) from exc
+        if history_path.exists():
+            try:
+                eval_history = json.loads(history_path.read_text(encoding="utf-8"))
+            except (json.JSONDecodeError, OSError) as exc:
+                raise ValueError(
+                    f"cannot resume {cfg.root}: private eval history is unreadable: {exc}"
+                ) from exc
         expected = list(range(1, start + 1))
         recorded = [row.get("episode") for row in eval_history]
         if len(eval_history) != start or recorded != expected:
@@ -283,12 +287,21 @@ def run(cfg: RunConfig, start: int = 0) -> RunResult:
             installed = json.loads(fingerprint_path.read_text(encoding="utf-8"))
             fingerprint = str(installed["fingerprint"])
         except (OSError, json.JSONDecodeError, KeyError, TypeError) as exc:
-            raise ValueError(
-                f"cannot resume {cfg.root}: disposition fingerprint record is unreadable: "
-                f"{exc}"
-            ) from exc
+            if start:
+                raise ValueError(
+                    f"cannot resume {cfg.root}: disposition fingerprint record is unreadable: "
+                    f"{exc}"
+                ) from exc
+            # A machine can die after episode-0 is committed but before this small private
+            # record is replaced. The restored checkpoint is the only completed state, so
+            # its fingerprint is a safe baseline from which to reconstruct the record.
+            fingerprint = cfg.adapter.disposition_fingerprint(harness)
+            _write_json_atomic(fingerprint_path, {"fingerprint": fingerprint})
         current = cfg.adapter.disposition_fingerprint(harness)
-        checkpoint_fingerprint = str(eval_history[-1].get("disposition_fingerprint", ""))
+        checkpoint_fingerprint = (
+            str(eval_history[-1].get("disposition_fingerprint", ""))
+            if start else fingerprint
+        )
         if not checkpoint_fingerprint or current != checkpoint_fingerprint:
             raise ValueError(
                 f"cannot resume {cfg.root}: current disposition fingerprint {current!r} "

--- a/proteus/scaffold.py
+++ b/proteus/scaffold.py
@@ -7,9 +7,9 @@
 The single source of truth for each skeleton is `examples/adapter_template.py` /
 `examples/benchmark_template.py` — this command copies one and renames the sentinel
 identifiers so `proteus check` (adapter) or the grader (benchmark) works immediately.
-Scaffolding is a source-checkout activity: the templates live under `examples/`, which is
-not shipped in the wheel, so run this from a clone (an editable `pip install -e .` is
-fine).
+The templates ship in both the wheel and source distribution. In a Git checkout the
+default destination is the matching `proteus/adapters/` or `proteus/bench/` directory;
+after a regular PyPI install it is the current directory, unless `--dest` is supplied.
 """
 
 from __future__ import annotations
@@ -21,8 +21,14 @@ from pathlib import Path
 
 
 def _repo_root() -> Path:
-    # proteus/ is a direct child of the repo root in a source checkout / editable install.
+    # proteus/ and the shipped examples/ package are siblings in both a source checkout
+    # and an unpacked wheel installation.
     return Path(__file__).resolve().parent.parent
+
+
+def _source_checkout() -> bool:
+    root = _repo_root()
+    return (root / "pyproject.toml").is_file() and (root / ".git").exists()
 
 
 def _dest_module(dest: Path) -> str:
@@ -63,7 +69,7 @@ def scaffold_benchmark(name: str, dest: Path, *, force: bool = False) -> Path:
 def _render(template: Path, dest: Path, subs: dict[str, str], *, force: bool) -> Path:
     if not template.exists():
         raise SystemExit(f"template not found: {template}\n"
-                         "run scaffold from a source checkout (see `pip install -e .`).")
+                         "reinstall proteus-evolve; wheels and sdists include examples/.")
     if dest.exists() and not force:
         raise SystemExit(f"{dest} already exists (use --force to overwrite)")
     text = template.read_text(encoding="utf-8")
@@ -94,14 +100,18 @@ def main(argv: list[str] | None = None) -> int:
     if args.kind == "adapter":
         short = re.sub(r"Harness$", "", args.name)
         short = re.sub(r"(?<!^)(?=[A-Z])", "_", short).lower()
-        dest = Path(args.dest) if args.dest else _repo_root() / "proteus" / "adapters" / f"{short}.py"
+        default = (_repo_root() / "proteus" / "adapters" / f"{short}.py"
+                   if _source_checkout() else Path.cwd() / f"{short}.py")
+        dest = Path(args.dest) if args.dest else default
         out = scaffold_adapter(args.name, dest, force=args.force)
         mod = _dest_module(out)
         cls = args.name if args.name.endswith("Harness") else args.name + "Harness"
         print(f"scaffolded {out}")
         print(f"next: implement the TODOs, then  proteus check --harness {mod}:{cls} --episode")
     else:
-        dest = Path(args.dest) if args.dest else _repo_root() / "proteus" / "bench" / f"{args.name}.py"
+        default = (_repo_root() / "proteus" / "bench" / f"{args.name}.py"
+                   if _source_checkout() else Path.cwd() / f"{args.name}.py")
+        dest = Path(args.dest) if args.dest else default
         out = scaffold_benchmark(args.name, dest, force=args.force)
         print(f"scaffolded {out}")
         print("next: implement setup()/grade(), then wire TASK into a run via as_goal(TASK)")

--- a/proteus/sweep.py
+++ b/proteus/sweep.py
@@ -10,15 +10,170 @@ from __future__ import annotations
 
 import json
 import shutil
-from dataclasses import dataclass
+from dataclasses import dataclass, field
 from pathlib import Path
-from typing import Callable, Sequence
+from typing import Any, Callable, Mapping, Sequence
 
 from proteus.core.adapter import HarnessAdapter
 from proteus.core.continuity import PROTOCOL_VERSION
 from proteus.core.disposition import Disposition
 from proteus.core.episode import RunConfig, completed_episodes, run
 from proteus.core.goal import GoalConfig
+
+
+MANIFEST_FORMAT_VERSION = 2
+
+
+class SweepStateError(ValueError):
+    """Existing sweep state cannot be safely reused."""
+
+
+def _json_value(value: Any) -> Any:
+    """Return a stable, JSON-safe representation for condition metadata."""
+    if value is None or isinstance(value, (bool, int, float, str)):
+        return value
+    if isinstance(value, Path):
+        return str(value.expanduser().resolve())
+    if isinstance(value, Mapping):
+        return {str(k): _json_value(v) for k, v in sorted(value.items(), key=lambda x: str(x[0]))}
+    if isinstance(value, (list, tuple, set, frozenset)):
+        values = [_json_value(v) for v in value]
+        return sorted(values, key=lambda v: json.dumps(v, sort_keys=True)) \
+            if isinstance(value, (set, frozenset)) else values
+    raise TypeError(
+        f"condition metadata must contain only JSON values and paths, got {type(value).__name__}"
+    )
+
+
+def _sha256_json(value: Any) -> str:
+    """Fingerprint a condition value without publishing its literal representation."""
+    import hashlib
+
+    encoded = json.dumps(
+        _json_value(value), sort_keys=True, separators=(",", ":")
+    ).encode()
+    return hashlib.sha256(encoded).hexdigest()
+
+
+def _disposition_condition(disposition: Disposition) -> dict:
+    """Identify a disposition without publishing its potentially sensitive prompt text."""
+    content = {
+        "prompt_suffix": disposition.prompt_suffix,
+        "per_phase": dict(disposition.per_phase),
+        "config": dict(disposition.config),
+        "patch": disposition.patch,
+    }
+    return {"label": disposition.label, "sha256": _sha256_json(content)}
+
+
+def _sandbox_condition(sandbox: object | None) -> dict | None:
+    """Describe an execution boundary without publishing private config values."""
+    if sandbox is None:
+        return None
+    out: dict[str, Any] = {
+        "type": f"{type(sandbox).__module__}:{type(sandbox).__qualname__}",
+    }
+    config = getattr(sandbox, "config", None)
+    if config is None:
+        return out
+    out["config"] = {
+        attr: _json_value(getattr(config, attr, None))
+        for attr in ("network", "image", "mem_limit", "cpus", "env_passthrough",
+                     "entrypoint", "workdir", "user")
+    }
+    # Literal env values, host mount paths, and arbitrary runner arguments may contain
+    # credentials or private paths. Their digests still make resume sensitive to a
+    # change without copying those values into the public manifest.
+    for attr in ("env", "extra_mounts", "extra_args"):
+        value = getattr(config, attr, {})
+        out["config"][attr] = {
+            "count": len(value),
+            "sha256": _sha256_json(value),
+        }
+    if isinstance(getattr(config, "env", None), Mapping):
+        out["config"]["env"]["keys"] = sorted(str(k) for k in config.env)
+    return out
+
+
+def _adapter_condition(adapter: HarnessAdapter) -> dict:
+    """Record public runtime knobs while deliberately excluding credentials."""
+    surfaces = [{
+        "name": s.name,
+        "subdir": s.subdir,
+        "unit": s.unit,
+        "write_tools": sorted(s.write_tools),
+        "is_code": s.is_code,
+        "free_named": s.free_named,
+    } for s in adapter.surfaces()]
+    out = {
+        "name": adapter.name,
+        "type": f"{type(adapter).__module__}:{type(adapter).__qualname__}",
+        "continuity_mode": getattr(adapter, "continuity_mode", "native"),
+        "staged_activation": bool(getattr(adapter, "staged_activation", False)),
+        "surfaces": surfaces,
+    }
+    runtime = {}
+    for attr in ("image", "network", "provider", "model", "base_url",
+                 "phase_timeout_s", "permission_mode"):
+        value = getattr(adapter, attr, None)
+        if value is not None:
+            runtime[attr] = _json_value(value)
+    sandbox = _sandbox_condition(getattr(adapter, "sandbox", None))
+    if sandbox is not None:
+        runtime["sandbox"] = sandbox
+    if runtime:
+        out["runtime"] = runtime
+    return out
+
+
+def _condition(cfg: "SweepConfig", adapter: HarnessAdapter) -> dict:
+    from proteus import __version__
+
+    task = None
+    if cfg.task is not None:
+        task = {
+            "id": str(getattr(cfg.task, "id", type(cfg.task).__name__)),
+            "base_commit": str(getattr(cfg.task, "base_commit", "")),
+        }
+    return {
+        "proteus_version": __version__,
+        "continuity_protocol_version": (
+            PROTOCOL_VERSION
+            if getattr(adapter, "continuity_mode", "native") == "framework" else None
+        ),
+        "adapter": _adapter_condition(adapter),
+        "arms": [_disposition_condition(arm) for arm in cfg.arms],
+        "seeds": cfg.seeds,
+        "episodes": cfg.episodes,
+        "model": cfg.model,
+        "max_turns": cfg.max_turns,
+        "min_turns_per_phase": cfg.min_turns_per_phase,
+        "announce_budget": cfg.announce_budget,
+        "goal": {
+            "text": cfg.goal.goal_text(),
+            "selection": cfg.goal.selection,
+            "evaluators": cfg.goal.describe(),
+        },
+        "task": task,
+        "grader_sandbox": _sandbox_condition(cfg.grader_sandbox),
+        "metadata": _json_value(cfg.condition_metadata),
+    }
+
+
+def _write_json_atomic(path: Path, value: Any) -> None:
+    temporary = path.with_name(path.name + ".tmp")
+    temporary.write_text(json.dumps(value, indent=1), encoding="utf-8")
+    temporary.replace(path)
+
+
+def _load_manifest(path: Path) -> dict:
+    try:
+        value = json.loads(path.read_text(encoding="utf-8"))
+    except (OSError, json.JSONDecodeError) as exc:
+        raise SweepStateError(f"cannot resume: manifest {path} is unreadable: {exc}") from exc
+    if not isinstance(value, dict):
+        raise SweepStateError(f"cannot resume: manifest {path} is not a JSON object")
+    return value
 
 
 @dataclass
@@ -50,6 +205,11 @@ class SweepConfig:
     contamination that is invisible in the output. "resume" skips seeds already recorded
     complete and picks a partial one up at the episode after its last snapshot; "overwrite"
     discards the old run roots."""
+    condition_metadata: Mapping[str, Any] = field(default_factory=dict)
+    """Additional non-secret inputs that define the experiment but cannot be inferred
+    from the adapter/evaluator contracts. The CLI records its raw evaluator specs here;
+    API callers with configurable custom evaluators should do the same. Resume compares
+    this metadata byte-for-byte after canonical JSON normalization."""
 
 
 def opaque_id(arm: str, seed: int) -> str:
@@ -104,23 +264,65 @@ def run_sweep(cfg: SweepConfig) -> list[dict]:
     if cfg.on_existing not in ("refuse", "resume", "overwrite"):
         raise ValueError(f"on_existing must be refuse/resume/overwrite, got {cfg.on_existing!r}")
     cfg.root.mkdir(parents=True, exist_ok=True)
-    if cfg.on_existing == "overwrite":
-        # discarding the run roots while appending to their records would leave two
-        # seed rows and two episode-1 progress lines per run — records go with the runs
-        (cfg.root / "seeds.jsonl").unlink(missing_ok=True)
-        shutil.rmtree(cfg.root / "progress", ignore_errors=True)
-    done = completed_seeds(cfg.root, cfg.episodes) if cfg.on_existing == "resume" else set()
-
-    # The adapter declaration is part of the experimental condition. Constructing one is
-    # side-effect free; individual runs still receive isolated adapter instances below.
-    manifest_adapter = cfg.adapter_factory()
-    continuity_mode = getattr(manifest_adapter, "continuity_mode", "native")
-
-    # manifest first: the live report discovers every planned run from it, so tracking
-    # works from episode 1 — not only after a seed completes
     runs = [{"id": opaque_id(arm.label, s), "arm": arm.label, "seed": s}
             for arm in cfg.arms for s in range(cfg.seeds)]
-    (cfg.root / "manifest.json").write_text(json.dumps({
+    manifest_path = cfg.root / "manifest.json"
+    records_path = cfg.root / "seeds.jsonl"
+    progress_path = cfg.root / "progress"
+    runs_path = cfg.root / "runs"
+    has_state = (manifest_path.exists() or records_path.exists() or progress_path.exists()
+                 or runs_path.exists())
+
+    # Constructing the declaration adapter is side-effect free. Its public runtime knobs
+    # form part of the condition; credentials are deliberately never inspected.
+    manifest_adapter = cfg.adapter_factory()
+    continuity_mode = getattr(manifest_adapter, "continuity_mode", "native")
+    condition = _condition(cfg, manifest_adapter)
+
+    # Validate before mutating anything. Previously even a refused second invocation
+    # replaced manifest.json, and resume could silently join episodes run under different
+    # goals/models into one trajectory.
+    existing_manifest = None
+    if cfg.on_existing == "refuse" and has_state:
+        raise FileExistsError(
+            f"{cfg.root} already holds sweep state. Refusing before changing its manifest; "
+            "use a fresh --out, or on_existing='resume' / 'overwrite'."
+        )
+    if cfg.on_existing == "resume" and has_state:
+        if not manifest_path.exists():
+            raise SweepStateError(
+                f"cannot resume {cfg.root}: existing run state has no manifest.json; "
+                "use overwrite or a fresh output directory"
+            )
+        existing_manifest = _load_manifest(manifest_path)
+        previous = existing_manifest.get("condition")
+        if existing_manifest.get("format_version") != MANIFEST_FORMAT_VERSION or not isinstance(
+            previous, dict
+        ):
+            raise SweepStateError(
+                f"cannot resume {cfg.root}: its manifest predates the v0.2 condition lock. "
+                "Finish it with the Proteus version that created it, or use overwrite/new --out."
+            )
+        if previous != condition:
+            changed = sorted(set(previous) | set(condition))
+            changed = [key for key in changed if previous.get(key) != condition.get(key)]
+            raise SweepStateError(
+                f"cannot resume {cfg.root}: experimental condition differs in "
+                f"{', '.join(changed)}; use the original configuration or a new --out"
+            )
+
+    if cfg.on_existing == "overwrite":
+        # Overwrite means the whole sweep, including private records nested below runs/.
+        # Clear it before publishing the new manifest so a crash cannot make old runs look
+        # as though they belong to the new condition.
+        records_path.unlink(missing_ok=True)
+        manifest_path.unlink(missing_ok=True)
+        shutil.rmtree(progress_path, ignore_errors=True)
+        shutil.rmtree(runs_path, ignore_errors=True)
+        has_state = False
+
+    manifest = {
+        "format_version": MANIFEST_FORMAT_VERSION,
         "name": cfg.name, "episodes": cfg.episodes,
         "arms": [a.label for a in cfg.arms], "seeds": cfg.seeds, "runs": runs,
         "model": cfg.model,
@@ -131,33 +333,29 @@ def run_sweep(cfg: SweepConfig) -> list[dict]:
             "mode": continuity_mode,
             "protocol_version": PROTOCOL_VERSION if continuity_mode == "framework" else None,
         },
-    }, indent=1))
+        "condition": condition,
+    }
+    # Preserve an already-validated resume manifest exactly. A refused or failed resume
+    # must be observationally read-only; a new/overwrite sweep publishes atomically.
+    if existing_manifest is None:
+        _write_json_atomic(manifest_path, manifest)
+
+    done = completed_seeds(cfg.root, cfg.episodes) if cfg.on_existing == "resume" else set()
 
     records: list[dict] = []
-    records_path = cfg.root / "seeds.jsonl"
     for arm in cfg.arms:
         for s in range(cfg.seeds):
             rid = opaque_id(arm.label, s)
             run_root = cfg.root / "runs" / rid
             start = 0
-            if run_root.exists():
-                if cfg.on_existing == "refuse":
-                    raise FileExistsError(
-                        f"{run_root} already holds a run of arm {arm.label!r} seed {s}. "
-                        "Sweeping into it again would continue that seed's evolved "
-                        "harness instead of starting clean. Use a fresh --out, or "
-                        "on_existing='resume' / 'overwrite'.")
+            run_root_existed = run_root.exists()
+            if run_root_existed:
                 if (arm.label, s) in done:
                     continue
-                if cfg.on_existing == "overwrite":
-                    shutil.rmtree(run_root)
-                else:
-                    # resume: pick the seed up where it stopped rather than paying for
-                    # its finished episodes twice
-                    start = completed_episodes_in(run_root)
-                    if start:
-                        print(f"resuming {arm.label} seed {s} at episode {start + 1}",
-                              flush=True)
+                # The refuse and overwrite cases were resolved before publishing the
+                # manifest, so an existing target here is a validated resume.
+                start = completed_episodes_in(run_root)
+                print(f"resuming {arm.label} seed {s} at episode {start + 1}", flush=True)
             rc = RunConfig(
                 name=arm.label, adapter=cfg.adapter_factory(), disposition=arm,
                 goal=cfg.goal, root=run_root, model=cfg.model,
@@ -167,7 +365,7 @@ def run_sweep(cfg: SweepConfig) -> list[dict]:
                 grader_sandbox=cfg.grader_sandbox,
                 progress_path=cfg.root / "progress" / f"{rid}.jsonl",
             )
-            res = run(rc, start=start)
+            res = run(rc, start=start, resume=run_root_existed)
             rec = {"arm": arm.label, "seed": s, "root": str(run_root),
                    "episodes_complete": res.episodes_complete, "error": res.error,
                    "counters": res.counters}

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "proteus-evolve"
-version = "0.1.0"
+dynamic = ["version"]
 description = "A harness-agnostic driver for measuring agent self-evolution: plug in any harness × model, evolve it under goal or no-goal conditions, and measure how the harness changes."
 readme = "README.md"
 requires-python = ">=3.10"
@@ -42,8 +42,11 @@ dev = ["pytest>=7.0", "ruff==0.14.14"]
 proteus = "proteus.cli:main"
 
 [tool.setuptools.packages.find]
-include = ["proteus*"]
+include = ["proteus*", "examples*"]
 namespaces = false  # do not crawl large run artefacts as implicit namespace packages
+
+[tool.setuptools.dynamic]
+version = {attr = "proteus.__version__"}
 
 [tool.ruff]
 line-length = 100

--- a/tests/test_conformance.py
+++ b/tests/test_conformance.py
@@ -115,6 +115,25 @@ def test_scaffold_adapter_roundtrip(tmp_path):
     assert check_adapter(cls(), episode=True, verbose=False) == []
 
 
+def test_adapter_factory_loads_scaffold_from_console_script_cwd(tmp_path, monkeypatch):
+    """Installed ``proteus`` scripts do not automatically put their cwd on sys.path."""
+    import sys
+
+    from proteus.cli import _adapter_factory
+    from proteus.scaffold import scaffold_adapter
+
+    scaffold_adapter("CwdHarness", tmp_path / "cwd.py")
+    monkeypatch.chdir(tmp_path)
+    monkeypatch.setattr(sys, "path", [p for p in sys.path if p not in ("", str(tmp_path))])
+    sys.modules.pop("cwd", None)
+    try:
+        cls = _adapter_factory("cwd:CwdHarness")
+        assert cls.name == "cwd"
+        assert check_adapter(cls(), episode=True, verbose=False) == []
+    finally:
+        sys.modules.pop("cwd", None)
+
+
 def test_scaffold_benchmark_roundtrip(tmp_path):
     from proteus.bench.task import BenchTask
     from proteus.scaffold import scaffold_benchmark

--- a/tests/test_goals.py
+++ b/tests/test_goals.py
@@ -260,6 +260,24 @@ def test_cli_run_returns_failure_when_an_episode_fails(tmp_path):
     assert rc == 1
 
 
+def test_cli_manifest_does_not_publish_contains_evaluator_needle(tmp_path):
+    import json
+
+    from proteus import cli
+
+    root = tmp_path / "private-evaluator"
+    rc = cli.main([
+        "run", "--harness", "minimal", "--arm", "neutral", "--seeds", "1",
+        "--episodes", "1", "--evaluator", "contains:AGENTS.md:private-needle",
+        "--out", str(root),
+    ])
+    assert rc == 0
+    manifest_text = (root / "manifest.json").read_text()
+    assert "private-needle" not in manifest_text
+    metadata = json.loads(manifest_text)["condition"]["metadata"]
+    assert len(metadata["evaluator_specs"][0]) == 64
+
+
 def test_cli_rejects_invalid_turn_reservations_without_traceback(tmp_path):
     from proteus import cli
 

--- a/tests/test_instrument.py
+++ b/tests/test_instrument.py
@@ -318,33 +318,138 @@ def _sweep_cfg(root: Path, **kw):
 
 
 def test_second_sweep_into_the_same_root_refuses(tmp_path):
+    import json
+
     from proteus.sweep import run_sweep
     root = tmp_path / "out"
     run_sweep(_sweep_cfg(root))
+    manifest = root / "manifest.json"
+    before = manifest.read_bytes()
+    changed = _sweep_cfg(root)
+    changed.model = "different-model"
     try:
-        run_sweep(_sweep_cfg(root))
+        run_sweep(changed)
     except FileExistsError as exc:
-        assert "on_existing" in str(exc)
+        assert "Refusing before changing" in str(exc)
     else:
         raise AssertionError("a second sweep silently reused the evolved run root")
+    assert manifest.read_bytes() == before, "a refused sweep rewrote the original manifest"
+    assert json.loads(manifest.read_text())["model"] == "mock"
 
 
 def test_sweep_manifest_records_the_model(tmp_path):
     import json
+    from proteus import __version__
     from proteus.sweep import run_sweep
 
     root = tmp_path / "out"
     run_sweep(_sweep_cfg(root))
     manifest = json.loads((root / "manifest.json").read_text())
     assert manifest["model"] == "mock"
+    assert manifest["condition"]["proteus_version"] == __version__
 
 
 def test_resume_skips_completed_seeds(tmp_path):
     from proteus.sweep import run_sweep
     root = tmp_path / "out"
     first = run_sweep(_sweep_cfg(root))
+    manifest = (root / "manifest.json").read_bytes()
     again = run_sweep(_sweep_cfg(root, on_existing="resume"))
     assert first and again == [], "resume re-ran a finished seed"
+    assert (root / "manifest.json").read_bytes() == manifest
+
+
+def test_resume_rejects_a_changed_experimental_condition(tmp_path):
+    import json
+
+    from proteus.core import GoalConfig
+    from proteus.sweep import SweepStateError, run_sweep
+
+    root = tmp_path / "out"
+    run_sweep(_sweep_cfg(root))
+    manifest = root / "manifest.json"
+    before = manifest.read_bytes()
+    changed = _sweep_cfg(root, on_existing="resume")
+    changed.goal = GoalConfig.of(text="a different objective")
+    changed.condition_metadata = {"evaluator_specs": ["tool-calls@observe"]}
+    from proteus.sandbox import LocalSandbox
+    changed.grader_sandbox = LocalSandbox()
+    try:
+        run_sweep(changed)
+    except SweepStateError as exc:
+        assert "condition differs" in str(exc)
+        assert "goal" in str(exc) and "metadata" in str(exc)
+        assert "grader_sandbox" in str(exc)
+    else:
+        raise AssertionError("resume mixed two experimental conditions")
+    assert manifest.read_bytes() == before, "a rejected resume rewrote the manifest"
+    assert json.loads(manifest.read_text())["goal"] == ""
+
+
+def test_manifest_fingerprints_private_sandbox_values(tmp_path):
+    import json
+
+    from proteus.adapters.minimal import MinimalHarness
+    from proteus.sandbox import DockerSandbox, SandboxConfig
+    from proteus.sweep import _adapter_condition
+
+    adapter = MinimalHarness()
+    adapter.sandbox = DockerSandbox(SandboxConfig(
+        env={"SERVICE_TOKEN": "do-not-publish"},
+        extra_mounts=((str(tmp_path / "private"), "/workspace/private"),),
+        extra_args=("--secret=also-private",),
+    ))
+    encoded = json.dumps(_adapter_condition(adapter), sort_keys=True)
+    assert "SERVICE_TOKEN" in encoded
+    assert "do-not-publish" not in encoded
+    assert str(tmp_path / "private") not in encoded
+    assert "also-private" not in encoded
+
+
+def test_resume_from_episode_zero_discards_a_crash_time_candidate(tmp_path):
+    from proteus.adapters.minimal import MinimalHarness
+    from proteus.core import EpisodeResult, GoalConfig, NEUTRAL, snapshot
+    from proteus.sweep import SweepConfig, opaque_id, run_sweep
+
+    class CrashOnceHarness(MinimalHarness):
+        continuity_mode = "framework"
+        attempts = 0
+
+        def run_episode(self, spec):
+            if type(self).attempts == 0:
+                type(self).attempts += 1
+                (spec.root / "harness" / "FIRST_PARTIAL.md").write_text("first attempt\n")
+                return EpisodeResult(spec.episode, ok=False, error="simulated power loss")
+            return super().run_episode(spec)
+
+    root = tmp_path / "episode-zero"
+
+    def config(on_existing="refuse"):
+        return SweepConfig(
+            name="ep0", adapter_factory=CrashOnceHarness, arms=[NEUTRAL], seeds=1,
+            goal=GoalConfig(), root=root, model="mock", episodes=1,
+            on_existing=on_existing,
+        )
+
+    first = run_sweep(config())
+    assert first[0]["episodes_complete"] == 0 and first[0]["error"]
+    run_root = root / "runs" / opaque_id("neutral", 0)
+    harness = run_root / "harness"
+    assert snapshot.commit_for_episode(harness, 0)
+
+    # This edit represents a SIGKILL after the framework's last handler ran. With no
+    # completed episode, the old implementation confused resume with a fresh seed and
+    # committed this dirty file into episode 1.
+    (harness / "CRASH_PARTIAL.md").write_text("must be discarded\n")
+    (run_root / ".proteus-state").mkdir(exist_ok=True)
+    (run_root / ".proteus-state" / "latest.md").write_text("partial handoff\n")
+
+    resumed = run_sweep(config("resume"))
+    assert resumed[0]["episodes_complete"] == 1 and not resumed[0]["error"]
+    assert not (harness / "CRASH_PARTIAL.md").exists()
+    assert not (harness / "FIRST_PARTIAL.md").exists()
+    assert not (run_root / ".proteus-state" / "latest.md").exists()
+    assert snapshot.commit_for_episode(harness, 1)
 
 
 # ------------------------------------------------------------------- user-set limits

--- a/web/server.py
+++ b/web/server.py
@@ -15,7 +15,7 @@ Trust model (v1):
 - Run ids are unguessable (uuid4); knowing the id grants read access to that run's
   progress — the sharable-link model.
 
-**Deployment posture (v0.1): localhost / trusted network only.** This server is not
+**Deployment posture (v0.2.0): localhost / trusted network only.** This server is not
 hardened for untrusted public exposure — there is no key redaction in logs, no auth on
 cancellation, and a request can name an arbitrary LLM `base_url`. Bind it to 127.0.0.1
 (the default) or put it behind an authenticating proxy; do not expose it raw to the


### PR DESCRIPTION
## Summary

- Make sweep resume condition-locked and observationally read-only before mutation.
- Restore the episode-0 durable checkpoint on interrupted first-episode recovery.
- Fingerprint private evaluator and sandbox values instead of publishing them in manifests.
- Ship adapter and benchmark templates in both wheel and sdist, including installed custom-harness loading.
- Use proteus.__version__ as the single package version source and set it to 0.2.0.
- Add v0.2.0 release notes, migration guidance, release documentation, and distribution smoke gates.

## Compatibility

v0.1 sweep manifests do not contain the v0.2 experimental condition lock. Proteus v0.2 therefore refuses to resume them; finish those runs with v0.1 or start a new output directory.

## Validation

- 114 passed, 1 skipped
- Offline runner: 98 passed, 0 failed
- Ruff and diff checks passed
- Wheel and sdist built and passed Twine checks
- Both distributions installed outside the checkout
- Installed scaffolder generated a conforming custom harness and benchmark
- Minimal two-episode release smoke: 0 failed checks

## Release sequence

After merge and green main CI, create the annotated v0.2.0 tag. Do not publish the GitHub Release until the pinned llm, DSH, and Pi release-smoke jobs are green.

Release notes: docs/releases/v0.2.0.md