### PR TITLE
fix: resume failed staged candidates for repair

### DIFF
--- a/README.md
+++ b/README.md
@@ -107,8 +107,9 @@ An installed action preference measurably shifts what the harness grows — and 
 extracts the pinned harness's real TypeScript source into `harness/src/`. During episode N,
 all four phases boot the same read-only last-valid snapshot while writing a separate
 candidate. After reflect, Proteus rebuilds and validates the candidate; only a passing
-candidate activates in episode N+1. A failed build is preserved for analysis and
-automatically rolled back, so the next episode remains healthy. The source is therefore a
+candidate activates in episode N+1. A failed build is prevented from activating, while
+its exact tree is restored as the next writable repair candidate; the next episode's
+running harness remains healthy. The source is therefore a
 measured, snapshotted `loop` surface alongside instructions, notes, tools, and skills. The
 adapters still leave the upstream repositories untouched: they arrange the run copy,
 launch one prepared container per phase, and parse the harness's own session logs.

--- a/docs/ADAPTERS.md
+++ b/docs/ADAPTERS.md
@@ -249,9 +249,10 @@ natively —
    edits are versioned per episode and measured with the same ruler as notes and tools.
 4. After reflect, `validate_candidate()` runs `--version` through the candidate boot path —
    the **model-free viability gate**. For pi that includes the rebuild, so a type error the
-   agent wrote surfaces with the build log tail. A failed candidate is preserved and
-   rolled back; the next episode remains healthy. A passing candidate first runs as the
-   controlling harness in episode N+1.
+   agent wrote surfaces with the build log tail. A failed candidate cannot activate: the
+   active line rolls back and remains healthy, while the exact failed tree is restored as
+   episode N+1's writable repair candidate. A passing candidate first runs as the
+   controlling harness one episode later.
 
 Verified live for both harnesses: a marker written into the real TypeScript entry point
 (`packages/coding-agent/src/cli.ts` for pi, `apps/cli/src/bin.ts` for dsh) appears on the

--- a/docs/EPISODE.md
+++ b/docs/EPISODE.md
@@ -50,7 +50,7 @@ The current implementation has two layers that must not be conflated:
 |---|---|---|
 | snapshot transaction and recovery | every adapter | accepted/rejected history, automatic restore after adapter or snapshot failure, strict resume from the last complete checkpoint |
 | frozen active + writable candidate | adapters declaring `staged_activation=True` | private `active_root`, isolation prompt, episode-boundary activation |
-| candidate viability | adapters implementing `validate_candidate()` | model-free gate before evaluators; failure is preserved, rejected, and rolled back |
+| candidate viability | adapters implementing `validate_candidate()` | model-free gate before evaluators; failure cannot activate, and staged adapters retain its exact tree as the next writable repair base |
 
 DSH and Pi implement all three layers. Minimal and LLM do not execute an editable copy of
 their own runtime, so they currently use the common snapshot transaction without staged
@@ -130,8 +130,10 @@ adapter's:
 
 An exception or `res.ok == False` preserves the partial candidate under
 `refs/proteus/candidates/episode-N-failed`, automatically restores files, index, and HEAD
-to the prior valid checkpoint, and ends the trajectory so resume can retry episode N. The
-attempt does **not** receive an `episode N` commit and therefore does not count as complete.
+to the prior valid checkpoint, and ends the trajectory so resume can retry episode N. For
+a staged adapter, the preserved commit is then restored only as that retry's writable
+candidate. The attempt does **not** receive an `episode N` commit and therefore does not
+count as complete.
 
 ### 4. Read the trace — adapter
 
@@ -152,8 +154,8 @@ control a model session.
   to activate in episode N+1;
 - **fail**: commit `candidate N [viability failed]`, restore the last valid state, commit
   the gapless `episode N [viability failed; rolled back]` checkpoint, record the build
-  error, and continue. Episode N+1 runs healthy code and receives the failure detail as
-  recovery feedback.
+  error, and continue. Episode N+1 runs healthy code, receives the failure detail, and
+  restores the exact failed tree into its separate writable candidate for repair.
 
 The gate runs before arbitrary evaluators, so invalid candidate code is not accidentally
 executed by benchmark or custom evaluation either. If an adapter does not implement the
@@ -195,7 +197,9 @@ A viability rejection uses the same preservation pattern with
 `candidate N [viability failed]` and
 `episode N [viability failed; rolled back]`. Unlike an infrastructure failure, it is a
 completed experimental episode: the failed evolutionary proposal is part of the
-trajectory, while its code is not allowed to control the next one.
+trajectory. Its code is not allowed to control the next one, but staged adapters reuse it
+as the next writable repair base. A valid but lower-scoring **selection** rejection does
+not carry forward; the configured outer loop deliberately rejected that candidate.
 
 Only `harness/` participates in selection. A benchmark task is the exercise rather than
 the measured subject, so `<run>/task/` moves forward and is not restored when a harness
@@ -213,10 +217,11 @@ candidate is rejected.
   `progress_path`, which **must live outside the run root**: the subject can read its
   own run root.
 
-Both evaluator history and the initial/candidate/checkpoint disposition fingerprints live
-under the sibling `.proteus-records/<run-id>/`, never inside the subject-visible run root.
-Resume requires the snapshot count, history rows, continuity checkpoint, and current
-fingerprint to agree with the last durable checkpoint.
+Evaluator history, the initial/candidate/checkpoint disposition fingerprints, and the
+temporary `pending_candidate.json` repair pointer live under the sibling
+`.proteus-records/<run-id>/`, never inside the subject-visible run root. Resume requires
+the snapshot count, history rows, continuity checkpoint, and current fingerprint to agree
+with the last durable checkpoint before it restores any pending tree on the writable side.
 
 At sweep level, `manifest.json` carries a versioned immutable `condition` record: adapter
 identity/runtime knobs, surfaces, disposition fingerprints, model, goal, evaluators, task,
@@ -226,10 +231,12 @@ manifest has no condition lock and is deliberately not resumable under v0.2.
 
 ### 10. Next episode — framework
 
-Context-fresh: the next episode materializes and boots the newly accepted snapshot. In a
-framework-continuity run, the prior reflect's bounded operational handoff also crosses the
-boundary as apparatus state; because it lives outside the harness snapshot, it cannot
-count as evolved memory. Raw conversation and process state never survive.
+Context-fresh: the next episode materializes and boots the last valid snapshot. Normally
+its writable candidate starts from the same tree; after a staged viability/infrastructure
+failure, only the writable side starts from the preserved failed commit. In a framework-
+continuity run, the prior reflect's bounded operational handoff also crosses the boundary
+as apparatus state; because it lives outside the harness snapshot, it cannot count as
+evolved memory. Raw conversation and process state never survive.
 
 ---
 
@@ -280,12 +287,12 @@ count as evolved memory. Raw conversation and process state never survive.
 
 | situation | outcome |
 |---|---|
-| a phase times out / the CLI exits nonzero | partial candidate is preserved under a dedicated ref; prior valid checkpoint is automatically restored; trajectory ends and resume retries the episode |
-| the agent breaks its own code | boundary gate preserves the failed candidate, rolls back automatically, records a rejected episode, and the next episode continues on healthy code |
+| a phase times out / the CLI exits nonzero | partial candidate is preserved under a dedicated ref; prior valid runtime is restored; resume retries the same episode with the partial tree as its writable repair candidate |
+| the agent breaks its own code | boundary gate preserves the failed candidate, keeps the next runtime on healthy code, and restores the failed tree as the next writable repair candidate |
 | one evaluator crashes or returns a non-finite score | that evaluator gets a named zero; other evaluator results survive |
 | a nested `.git` appears in the harness | the episode records a snapshot error; nested metadata is refused and automatic restore removes its contents |
 | the episode is rejected by selection | candidate tree preserved in history, working tree rolled back, mapping gapless |
-| the process is killed mid-run | no handler can run at kill time; `--on-existing resume` first hard-restores the last complete checkpoint, then retries without the dirty partial candidate |
+| the process is killed mid-run | for staged adapters, resume captures the dirty tree under a failed-attempt ref, restores the last-valid runtime, and retries with that tree as writable candidate; native adapters hard-restore the checkpoint |
 
 ## Invariants to test in every staged adapter
 
@@ -294,7 +301,9 @@ count as evolved memory. Raw conversation and process state never survive.
 3. Reflect can inspect candidate/diff but cannot reload candidate as its own harness.
 4. Validation happens once, after reflect and before arbitrary evaluators.
 5. A valid candidate first controls episode N+1, never episode N.
-6. A validation failure preserves evidence, restores the prior valid tree, and still
-   creates a gapless rejected episode checkpoint.
-7. An adapter/provider/snapshot failure restores but does not count the incomplete episode.
-8. Resume removes any crash-time dirty candidate before the next attempt.
+6. A validation failure preserves evidence, restores the prior valid active tree, creates
+   a gapless rejected checkpoint, and restores the failed tree only on the writable side.
+7. An adapter/provider failure does not count the incomplete episode; a staged retry gets
+   its preserved partial candidate while its active runtime stays at the checkpoint.
+8. Resume captures staged crash-time edits before reset and restores them as the writable
+   repair base. Native adapters, which cannot isolate active from candidate, discard them.

--- a/docs/MEASUREMENTS.md
+++ b/docs/MEASUREMENTS.md
@@ -29,7 +29,8 @@ runs/demo/
 └── runs/
     ├── .proteus-records/<run-id>/ # framework-private; outside the subject run root
     │   ├── eval_history.json      # evaluator results and accept/reject decisions
-    │   └── disposition_fingerprint.json
+    │   ├── disposition_fingerprint.json
+    │   └── pending_candidate.json # present only while a staged failure awaits repair
     └── <run-id>/
         ├── harness/               # current measured harness state
         ├── task/                  # optional benchmark; not measured/snapshotted

--- a/docs/RECIPES.md
+++ b/docs/RECIPES.md
@@ -94,8 +94,9 @@ For both source adapters, an unchanged source takes a pristine fast path. A chan
 is exact-synced, rebuilt once per source hash, cached under `/state`, and rejected by the
 post-reflect viability gate if it cannot boot. Every phase within an episode runs the same
 frozen snapshot; a valid candidate activates only in the next episode, while an invalid one
-is preserved and automatically rolled back. Containers run as the host uid/gid so their
-bind-mounted files remain editable on Linux.
+is blocked from activation and restored as the next episode's writable repair base. The
+running harness remains the last-valid snapshot. Containers run as the host uid/gid so
+their bind-mounted files remain editable on Linux.
 
 ## Watch, measure, audit, resume, and export
 

--- a/docs/releases/v0.2.0.md
+++ b/docs/releases/v0.2.0.md
@@ -14,10 +14,13 @@ only after its normal build/boot path succeeds.
   Persistent edits go to a separate candidate and activate no earlier than episode N+1.
 - The episode-boundary viability gate rebuilds and boots self-edited source before an
   evaluator can execute it. Invalid candidates are retained as inspectable candidate
-  commits, scored as rejected episodes, and automatically rolled back.
-- Adapter/provider/snapshot failures preserve each failed attempt without advancing the
-  episode number. Resume restores files, the Git index, HEAD, evaluator state, selection
-  baseline, disposition fingerprint, and framework handoff to the last durable checkpoint.
+  commits and scored as rejected episodes. Their code never activates, but the exact tree
+  becomes the next episode's writable repair base while the runtime remains last-valid.
+- Adapter/provider failures preserve each snapshot-able failed attempt without advancing
+  the episode number; staged retries receive that exact tree as their writable repair base.
+  Snapshot failures still restore files, the Git index, and HEAD. Resume also restores
+  evaluator state, selection baseline, disposition fingerprint, and framework handoff to
+  the last durable checkpoint.
 - Episode-0 recovery is explicit: a process killed before its first completed episode can
   no longer leak a half-written candidate into episode 1.
 

--- a/proteus/adapters/dsh.py
+++ b/proteus/adapters/dsh.py
@@ -62,7 +62,8 @@ candidate surfaces are:
 - `/workspace/candidate/tools/` — small node utilities you may want later
 - `/workspace/candidate/src/` — your own program: the real TypeScript source of the
   harness that runs you. Proteus validates it only after reflect. A valid candidate is
-  activated in the next episode; an invalid one is preserved for analysis and rolled back.
+  activated in the next episode. An invalid one cannot run, but its exact tree becomes the
+  next episode's writable candidate so you can repair it instead of starting over.
 
 Proteus supplies the cross-phase operational handoff at
 `/workspace/.proteus/handoff.md`. Read and replace it as requested by each phase prompt. It is

--- a/proteus/adapters/pi.py
+++ b/proteus/adapters/pi.py
@@ -55,7 +55,8 @@ candidate surfaces are:
 - `/workspace/candidate/skills/` — pi skill files, loaded after activation
 - `/workspace/candidate/src/` — your own program: the real TypeScript source of the
   agent that runs you. Proteus validates it only after reflect. A valid candidate is
-  activated in the next episode; an invalid one is preserved for analysis and rolled back.
+  activated in the next episode. An invalid one cannot run, but its exact tree becomes the
+  next episode's writable candidate so you can repair it instead of starting over.
 
 Proteus supplies the cross-phase operational handoff at
 `/workspace/.proteus/handoff.md`. Read and replace it as requested by each phase prompt. It is

--- a/proteus/core/episode.py
+++ b/proteus/core/episode.py
@@ -49,6 +49,85 @@ def eval_history_path(root: Path) -> Path:
     """Durable evaluator history, including scores hidden from the subject."""
     return private_record_dir(root) / "eval_history.json"
 
+
+PENDING_CANDIDATE_VERSION = 1
+
+
+def pending_candidate_path(root: Path) -> Path:
+    """Framework-private pointer to a failed staged candidate awaiting repair."""
+    return private_record_dir(root) / "pending_candidate.json"
+
+
+def _write_pending_candidate(root: Path, *, commit: str, resume_episode: int,
+                             reason: str, error: str) -> dict:
+    record = {
+        "version": PENDING_CANDIDATE_VERSION,
+        "commit": commit,
+        "resume_episode": resume_episode,
+        "reason": reason,
+        "error": str(error)[:2000],
+    }
+    _write_json_atomic(pending_candidate_path(root), record)
+    return record
+
+
+def _load_pending_candidate(root: Path, harness: Path, expected_episode: int) -> dict | None:
+    """Load the exact failed tree to use as a staged episode's writable repair base."""
+    path = pending_candidate_path(root)
+    if not path.exists():
+        return None
+    try:
+        record = json.loads(path.read_text(encoding="utf-8"))
+        version = int(record["version"])
+        commit = str(record["commit"])
+        resume_episode = int(record["resume_episode"])
+        reason = str(record["reason"])
+        error = str(record.get("error", ""))
+    except (OSError, json.JSONDecodeError, KeyError, TypeError, ValueError) as exc:
+        raise ValueError(f"pending staged candidate is unreadable at {path}: {exc}") from exc
+    if version != PENDING_CANDIDATE_VERSION:
+        raise ValueError(
+            f"pending staged candidate at {path} has unsupported version {version}"
+        )
+    if resume_episode < expected_episode:
+        # The process can die after committing an accepted episode but before deleting
+        # the repair pointer. The durable episode checkpoint wins; this pointer is stale.
+        path.unlink(missing_ok=True)
+        return None
+    if resume_episode != expected_episode:
+        raise ValueError(
+            f"pending staged candidate targets episode {resume_episode}, but the next "
+            f"durable episode is {expected_episode}"
+        )
+    if not snapshot.has_commit(harness, commit):
+        raise ValueError(
+            f"pending staged candidate {commit!r} is missing from the snapshot repository"
+        )
+    return {
+        "version": version,
+        "commit": commit,
+        "resume_episode": resume_episode,
+        "reason": reason,
+        "error": error,
+    }
+
+
+def _clear_pending_candidate(root: Path) -> None:
+    pending_candidate_path(root).unlink(missing_ok=True)
+
+
+def _repair_feedback(pending: dict, prior: str = "") -> str:
+    detail = str(pending.get("error", ""))[:600]
+    notice = (
+        "Proteus restored the exact failed candidate as this episode's writable repair "
+        "base. The running harness is still the last valid snapshot; inspect and fix the "
+        "candidate rather than rebuilding the change from scratch."
+    )
+    if detail:
+        notice += f" Previous failure: {detail}"
+    return f"{notice}\n\n{prior}" if prior else notice
+
+
 BASE_PROMPTS: Mapping[str, str] = {
     "observe": (
         "Take stock of the harness you woke up in: what is here, what state it is in, "
@@ -133,7 +212,9 @@ def _phase_prompts(cfg: RunConfig, prior_feedback: str) -> dict[str, str]:
             "do not become the running harness in any phase of this episode, including "
             "reflect; do not replace or reload the active process from the candidate. "
             "Reflect may inspect the candidate and its diff. Proteus validates it after "
-            "reflect and activates it only in the next episode if the gate passes."
+            "reflect and activates it only in the next episode if the gate passes. If a "
+            "prior candidate failed viability, this writable tree is that exact failed "
+            "candidate restored for repair; the active runtime still remains last-valid."
         )
         for ph in PHASES:
             prompts[ph] = f"{staging_note}\n\n{prompts[ph]}"
@@ -218,6 +299,8 @@ def run(cfg: RunConfig, start: int = 0, *, resume: bool = False) -> RunResult:
     skipped entirely.
     """
     harness = cfg.root / "harness"
+    records = private_record_dir(cfg.root)
+    staged_activation = bool(getattr(cfg.adapter, "staged_activation", False))
     if cfg.max_turns and cfg.min_turns_per_phase * len(PHASES) > cfg.max_turns:
         raise ValueError(
             f"max_turns={cfg.max_turns} cannot honour min_turns_per_phase="
@@ -235,15 +318,27 @@ def run(cfg: RunConfig, start: int = 0, *, resume: bool = False) -> RunResult:
         if checkpoint is None:  # guarded by completed == start; keep the failure legible
             raise ValueError(
                 f"cannot resume {cfg.root}: episode {start} checkpoint is missing")
-        # A normal adapter/provider failure restores before returning, but SIGKILL or a
-        # machine restart cannot run that handler. Never let its dirty, half-written
-        # candidate leak into the resumed episode: files, index, and HEAD all return to the
-        # last complete episode before continuity/fingerprint checks run.
-        snapshot.reset_to_checkpoint(harness, checkpoint)
+        # A normal adapter/provider failure has already committed its staged candidate.
+        # SIGKILL cannot run that handler, so capture any dirty (or just-committed) staged
+        # tree before resetting. It is a repair base only: the executable active snapshot
+        # still comes from `checkpoint` below.
+        interrupted = ""
+        if staged_activation:
+            interrupted = snapshot.preserve_interrupted_candidate(
+                harness, checkpoint, start + 1,
+                f"candidate {start + 1}: {cfg.name} [interrupted before checkpoint]",
+            )
+        else:
+            snapshot.reset_to_checkpoint(harness, checkpoint)
+        if interrupted:
+            _write_pending_candidate(
+                cfg.root, commit=interrupted, resume_episode=start + 1,
+                reason="interrupted", error="process stopped before an episode checkpoint",
+            )
     else:
         # A fresh/overwrite run must not inherit hidden scores or an F baseline from an
         # older run directory with the same deterministic id.
-        shutil.rmtree(private_record_dir(cfg.root), ignore_errors=True)
+        shutil.rmtree(records, ignore_errors=True)
         cfg.adapter.seed(harness, cfg.seed)
         cfg.adapter.install_disposition(harness, cfg.disposition)
         if cfg.task is not None:
@@ -259,7 +354,6 @@ def run(cfg: RunConfig, start: int = 0, *, resume: bool = False) -> RunResult:
     prior_feedback = ""
     totals: dict = {}
     best_score: float | None = None
-    records = private_record_dir(cfg.root)
     history_path = eval_history_path(cfg.root)
     fingerprint_path = records / "disposition_fingerprint.json"
     fingerprint = cfg.adapter.disposition_fingerprint(harness)
@@ -334,12 +428,27 @@ def run(cfg: RunConfig, start: int = 0, *, resume: bool = False) -> RunResult:
                                   if prior_feedback else recovery)
             elif prior_feedback and not last.get("accepted", True):
                 prior_feedback += "\n(Your last episode's changes were not kept.)"
+    pending = (
+        _load_pending_candidate(cfg.root, harness, start + 1)
+        if staged_activation else None
+    )
+    if pending:
+        if pending["reason"] == "viability" and eval_history:
+            # Replace the older generic rollback wording while retaining only evaluator
+            # feedback the agent is allowed to observe.
+            from proteus.core.goal import EvalResult
+            last_results = {
+                r["name"]: EvalResult(**r) for r in (eval_history[-1].get("results") or [])
+            }
+            prior_feedback = cfg.goal.observe_feedback(last_results)
+        prior_feedback = _repair_feedback(pending, prior_feedback)
     error = ""
     done = start
-    last_accepted = snapshot.head(harness)   # episode-0 state, or the resume point
+    last_checkpoint = snapshot.head(harness)  # gapless episode mapping, including rollbacks
+    last_accepted = last_checkpoint            # same valid tree at start/resume
     for ep in range(start + 1, cfg.episodes + 1):
         active_root = None
-        if getattr(cfg.adapter, "staged_activation", False):
+        if staged_activation:
             # Keep the executable snapshot outside both the writable candidate and the
             # agent-visible handoff mount. If it lived under `.proteus-state`, the latter's
             # writable nested mount would give the subject a back door into its supposedly
@@ -348,6 +457,11 @@ def run(cfg: RunConfig, start: int = 0, *, resume: bool = False) -> RunResult:
             active_root = private_record_dir(cfg.root) / "active"
             shutil.rmtree(active_root, ignore_errors=True)
             snapshot.materialize(harness, last_accepted, active_root)
+            if pending and pending["resume_episode"] == ep:
+                # Only the writable side resumes from the failure. HEAD stays on the
+                # durable rollback checkpoint, and active_root was already materialised
+                # from the last valid tree, so failed code cannot execute in this episode.
+                snapshot.restore(harness, pending["commit"])
         spec = EpisodeSpec(
             root=cfg.root, episode=ep, model=cfg.model,
             phase_prompts=_phase_prompts(cfg, prior_feedback),
@@ -361,20 +475,30 @@ def run(cfg: RunConfig, start: int = 0, *, resume: bool = False) -> RunResult:
         except Exception as exc:  # noqa: BLE001 - a failed episode is a record, not a crash
             error = f"{type(exc).__name__}: {exc}"
             try:
-                snapshot.preserve_failed_candidate(
-                    harness, last_accepted, ep,
+                failed_commit = snapshot.preserve_failed_candidate(
+                    harness, last_checkpoint, ep,
                     f"candidate {ep}: {cfg.name} [run failed: {type(exc).__name__}]",
                 )
+                if staged_activation:
+                    pending = _write_pending_candidate(
+                        cfg.root, commit=failed_commit, resume_episode=ep,
+                        reason="run_failed", error=error,
+                    )
             except Exception as restore_exc:  # noqa: BLE001
                 error += f"; automatic restore failed: {restore_exc}"
             break
         if not res.ok:
             error = res.error
             try:
-                snapshot.preserve_failed_candidate(
-                    harness, last_accepted, ep,
+                failed_commit = snapshot.preserve_failed_candidate(
+                    harness, last_checkpoint, ep,
                     f"candidate {ep}: {cfg.name} [run failed]",
                 )
+                if staged_activation:
+                    pending = _write_pending_candidate(
+                        cfg.root, commit=failed_commit, resume_episode=ep,
+                        reason="run_failed", error=error,
+                    )
             except Exception as restore_exc:  # noqa: BLE001
                 error += f"; automatic restore failed: {restore_exc}"
             break
@@ -421,24 +545,40 @@ def run(cfg: RunConfig, start: int = 0, *, resume: bool = False) -> RunResult:
             else:
                 best_score = score
 
+        candidate_commit = ""
         try:
             if accepted:
-                last_accepted = snapshot.commit(harness, f"episode {ep}: {cfg.name}")
+                candidate_commit = snapshot.commit(harness, f"episode {ep}: {cfg.name}")
+                last_accepted = candidate_commit
             else:
                 # non-destructive rejection: the rejected candidate tree goes into history
                 # first (as "candidate N:", outside the episode->commit mapping), then the
                 # restore is committed as episode N so the mapping stays gapless
                 reason = "viability failed" if viability_error else "rejected"
-                snapshot.commit(harness, f"candidate {ep}: {cfg.name} [{reason}]")
+                candidate_commit = snapshot.commit(
+                    harness, f"candidate {ep}: {cfg.name} [{reason}]"
+                )
                 snapshot.restore(harness, last_accepted)
                 snapshot.commit(harness, f"episode {ep}: {cfg.name} [{reason}; rolled back]")
         except Exception as exc:  # noqa: BLE001 - one bad subject must not abort a sweep
             error = f"snapshot failed after episode {ep}: {type(exc).__name__}: {exc}"
             try:
-                snapshot.reset_to_checkpoint(harness, last_accepted)
+                snapshot.reset_to_checkpoint(harness, last_checkpoint)
             except Exception as restore_exc:  # noqa: BLE001
                 error += f"; automatic restore failed: {restore_exc}"
             break
+        last_checkpoint = snapshot.head(harness)
+        if viability_error and staged_activation:
+            pending = _write_pending_candidate(
+                cfg.root, commit=candidate_commit, resume_episode=ep + 1,
+                reason="viability", error=viability_error,
+            )
+        else:
+            # Accepted evolution advances the active line. A valid but lower-scoring
+            # selection rejection deliberately starts over from last-valid rather than
+            # inheriting a candidate the configured outer loop rejected.
+            pending = None
+            _clear_pending_candidate(cfg.root)
         checkpoint_fingerprint = cfg.adapter.disposition_fingerprint(harness)
         done = ep
         for key, value in (res.counters or {}).items():
@@ -448,6 +588,7 @@ def run(cfg: RunConfig, start: int = 0, *, resume: bool = False) -> RunResult:
         eval_history.append({"episode": ep, "accepted": accepted,
                              "results": [r.__dict__ for r in results],
                              "counters": dict(res.counters or {}),
+                             "candidate_commit": candidate_commit,
                              "candidate_fingerprint": candidate_fingerprint,
                              "disposition_fingerprint": checkpoint_fingerprint,
                              "disposition_drift": candidate_fingerprint != fingerprint,
@@ -460,10 +601,17 @@ def run(cfg: RunConfig, start: int = 0, *, resume: bool = False) -> RunResult:
         _write_json_atomic(history_path, eval_history)
         prior_feedback = cfg.goal.observe_feedback(by_name)  # OBSERVE-visible only
         if viability_error:
-            recovery = ("Your last candidate failed the episode-boundary viability gate "
-                        "and was rolled back. Fix the underlying issue in a new candidate: "
-                        f"{viability_error[:600]}")
-            prior_feedback = f"{recovery}\n\n{prior_feedback}" if prior_feedback else recovery
+            if pending:
+                prior_feedback = _repair_feedback(pending, prior_feedback)
+            else:
+                recovery = (
+                    "Your last candidate failed the episode-boundary viability gate and "
+                    "was rolled back. Fix the underlying issue in a new candidate: "
+                    f"{viability_error[:600]}"
+                )
+                prior_feedback = (
+                    f"{recovery}\n\n{prior_feedback}" if prior_feedback else recovery
+                )
         elif prior_feedback and not accepted:
             prior_feedback += "\n(Your last episode's changes were not kept.)"
 

--- a/proteus/core/snapshot.py
+++ b/proteus/core/snapshot.py
@@ -84,6 +84,27 @@ def head(work_tree: Path) -> str:
         return ""
 
 
+def has_changes(work_tree: Path) -> bool:
+    """Whether files/index differ from HEAD, including ignored and untracked files."""
+    # Snapshot repos deliberately disable ignore rules for commits, but status still needs
+    # --ignored to expose an interrupted candidate file matched by its own .gitignore.
+    lines = _git(
+        work_tree, "status", "--porcelain", "--untracked-files=all", "--ignored=matching"
+    ).splitlines()
+    return bool(lines)
+
+
+def has_commit(work_tree: Path, sha: str) -> bool:
+    """Return whether ``sha`` names a commit in this run's private snapshot repository."""
+    if not sha:
+        return False
+    try:
+        _git(work_tree, "cat-file", "-e", f"{sha}^{{commit}}")
+    except RuntimeError:
+        return False
+    return True
+
+
 def _nested_git_metadata(work_tree: Path) -> list[Path]:
     """Every nested `.git` file/dir, without descending into repository internals."""
     found: list[Path] = []
@@ -137,6 +158,21 @@ def restore(work_tree: Path, sha: str) -> None:
     _git(work_tree, "clean", "-fdx")
 
 
+def _keep_failed_ref(work_tree: Path, candidate: str, episode: int) -> str:
+    """Give a candidate commit the next durable failed-attempt ref for an episode."""
+    base = f"refs/proteus/candidates/episode-{episode}-failed"
+    existing = set(_git(
+        work_tree, "for-each-ref", "--format=%(refname)", f"{base}*"
+    ).splitlines())
+    ref = base
+    attempt = 2
+    while ref in existing:
+        ref = f"{base}-attempt-{attempt}"
+        attempt += 1
+    _git(work_tree, "update-ref", ref, candidate)
+    return ref
+
+
 def preserve_failed_candidate(work_tree: Path, restore_sha: str, episode: int,
                               message: str) -> str:
     """Keep a failed attempt under a dedicated ref, then restore the valid checkpoint.
@@ -151,16 +187,31 @@ def preserve_failed_candidate(work_tree: Path, restore_sha: str, episode: int,
     candidate = ""
     try:
         candidate = commit(work_tree, message)
-        base = f"refs/proteus/candidates/episode-{episode}-failed"
-        existing = set(_git(
-            work_tree, "for-each-ref", "--format=%(refname)", f"{base}*"
-        ).splitlines())
-        ref = base
-        attempt = 2
-        while ref in existing:
-            ref = f"{base}-attempt-{attempt}"
-            attempt += 1
-        _git(work_tree, "update-ref", ref, candidate)
+        _keep_failed_ref(work_tree, candidate, episode)
+    finally:
+        reset_to_checkpoint(work_tree, restore_sha)
+    return candidate
+
+
+def preserve_interrupted_candidate(work_tree: Path, restore_sha: str, episode: int,
+                                   message: str) -> str:
+    """Capture crash-time staged work, including a commit made just before the crash.
+
+    During model phases HEAD remains at the durable checkpoint and edits are dirty. A
+    machine can also die in the tiny boundary window after candidate commit but before
+    rollback, where HEAD already names the candidate and status is clean. Both cases are
+    retained under the normal failed-attempt refs, then the worktree and HEAD are reset.
+    """
+    candidate = ""
+    try:
+        current = head(work_tree)
+        dirty = has_changes(work_tree)
+        if dirty:
+            candidate = commit(work_tree, message)
+        elif current and current != restore_sha:
+            candidate = current
+        if candidate:
+            _keep_failed_ref(work_tree, candidate, episode)
     finally:
         reset_to_checkpoint(work_tree, restore_sha)
     return candidate

--- a/tests/test_instrument.py
+++ b/tests/test_instrument.py
@@ -106,7 +106,7 @@ def test_snapshot_failure_becomes_a_seed_error(tmp_path):
 def test_staged_candidate_is_frozen_until_next_episode_and_bad_build_rolls_back(tmp_path):
     from proteus.adapters.minimal import MinimalHarness
     from proteus.core import EpisodeResult, EvaluatorSpec, GoalConfig, NEUTRAL
-    from proteus.core.episode import RunConfig, run
+    from proteus.core.episode import RunConfig, pending_candidate_path, run
     from proteus.core.goal import EvalResult
 
     class StagedHarness(MinimalHarness):
@@ -122,6 +122,7 @@ def test_staged_candidate_is_frozen_until_next_episode_and_bad_build_rolls_back(
             self.active_observations.append({
                 "episode": spec.episode,
                 "broken_before": (active / "BROKEN").exists(),
+                "candidate_broken_before": (candidate / "BROKEN").exists(),
             })
             if spec.episode == 1:
                 (candidate / "BROKEN").write_text("does not compile\n")
@@ -129,6 +130,9 @@ def test_staged_candidate_is_frozen_until_next_episode_and_bad_build_rolls_back(
                 self.active_observations[-1]["broken_after_act"] = (
                     active / "BROKEN").exists()
             else:
+                assert (candidate / "BROKEN").read_text() == "does not compile\n", \
+                    "the failed candidate was not restored as the next repair base"
+                (candidate / "BROKEN").unlink()
                 (candidate / "notes").mkdir(exist_ok=True)
                 (candidate / "notes" / "recovered.md").write_text("healthy\n")
             return EpisodeResult(episode=spec.episode, ok=True)
@@ -152,16 +156,20 @@ def test_staged_candidate_is_frozen_until_next_episode_and_bad_build_rolls_back(
 
     assert result.episodes_complete == 2 and not result.error
     assert adapter.active_observations == [
-        {"episode": 1, "broken_before": False, "broken_after_act": False},
-        {"episode": 2, "broken_before": False},
+        {"episode": 1, "broken_before": False, "candidate_broken_before": False,
+         "broken_after_act": False},
+        {"episode": 2, "broken_before": False, "candidate_broken_before": True},
     ]
     assert not result.eval_history[0]["accepted"]
     assert result.eval_history[0]["failure_kind"] == "viability"
     assert "compile failed" in result.eval_history[0]["error"]
+    assert result.eval_history[0]["candidate_commit"]
     assert result.eval_history[1]["accepted"]
     assert evaluated == [2], "an invalid candidate reached arbitrary evaluator code"
     assert not (root / "harness" / "BROKEN").exists()
     assert (root / "harness" / "notes" / "recovered.md").exists()
+    assert not pending_candidate_path(root).exists(), \
+        "an accepted repair left a stale pending-candidate pointer"
     assert not (root / ".proteus-state" / "active").exists(), \
         "the frozen runtime leaked into the writable handoff mount"
 
@@ -203,6 +211,178 @@ def test_incomplete_episode_preserves_candidate_ref_and_restores_checkpoint(tmp_
         capture_output=True, text=True, check=True,
     ).stdout
     assert preserved == "keep for analysis\n"
+
+
+def test_staged_incomplete_candidate_is_restored_on_same_episode_retry(tmp_path):
+    from proteus.adapters.minimal import MinimalHarness
+    from proteus.core import EpisodeResult, GoalConfig, NEUTRAL
+    from proteus.core.episode import RunConfig, pending_candidate_path, run
+
+    class RetryHarness(MinimalHarness):
+        staged_activation = True
+
+        def __init__(self):
+            super().__init__()
+            self.attempt = 0
+            self.observations = []
+
+        def run_episode(self, spec):
+            active = Path(spec.active_root)
+            candidate = spec.root / "harness"
+            self.observations.append({
+                "episode": spec.episode,
+                "active_partial": (active / "PARTIAL.md").exists(),
+                "candidate_partial": (candidate / "PARTIAL.md").exists(),
+            })
+            self.attempt += 1
+            if self.attempt == 1:
+                (candidate / "PARTIAL.md").write_text("continue me\n")
+                return EpisodeResult(spec.episode, ok=False, error="provider unavailable")
+            assert (candidate / "PARTIAL.md").read_text() == "continue me\n"
+            (candidate / "PARTIAL.md").write_text("finished\n")
+            return EpisodeResult(spec.episode, ok=True)
+
+    adapter = RetryHarness()
+    root = tmp_path / "retry-run"
+    cfg = RunConfig(
+        name="retry", adapter=adapter, disposition=NEUTRAL, goal=GoalConfig(),
+        root=root, model="mock", episodes=1,
+    )
+    first = run(cfg)
+    assert first.episodes_complete == 0 and first.error == "provider unavailable"
+    assert pending_candidate_path(root).exists()
+
+    second = run(cfg, start=0, resume=True)
+    assert second.episodes_complete == 1 and not second.error
+    assert adapter.observations == [
+        {"episode": 1, "active_partial": False, "candidate_partial": False},
+        {"episode": 1, "active_partial": False, "candidate_partial": True},
+    ]
+    assert (root / "harness" / "PARTIAL.md").read_text() == "finished\n"
+    assert not pending_candidate_path(root).exists()
+
+
+def test_failed_repair_keeps_completed_rollback_checkpoint_and_candidate(tmp_path):
+    from proteus.adapters.minimal import MinimalHarness
+    from proteus.core import EpisodeResult, GoalConfig, NEUTRAL
+    from proteus.core.episode import RunConfig, completed_episodes, run
+
+    class RetryAfterRollbackHarness(MinimalHarness):
+        staged_activation = True
+
+        def __init__(self):
+            super().__init__()
+            self.episode_two_attempts = 0
+
+        def run_episode(self, spec):
+            active = Path(spec.active_root)
+            candidate = spec.root / "harness"
+            assert not (active / "BROKEN").exists()
+            if spec.episode == 1:
+                (candidate / "BROKEN").write_text("bad build\n")
+            else:
+                self.episode_two_attempts += 1
+                if self.episode_two_attempts == 1:
+                    assert (candidate / "BROKEN").read_text() == "bad build\n"
+                    (candidate / "PARTIAL_FIX").write_text("keep this repair\n")
+                    return EpisodeResult(
+                        spec.episode, ok=False, error="provider unavailable"
+                    )
+                assert (candidate / "PARTIAL_FIX").read_text() == "keep this repair\n"
+                (candidate / "BROKEN").unlink()
+                (candidate / "FIXED").write_text("yes\n")
+            return EpisodeResult(spec.episode, ok=True)
+
+        def validate_candidate(self, harness_root):
+            return "compile failed" if (Path(harness_root) / "BROKEN").exists() else ""
+
+    adapter = RetryAfterRollbackHarness()
+    root = tmp_path / "retry-after-rollback"
+    cfg = RunConfig(
+        name="repair", adapter=adapter, disposition=NEUTRAL, goal=GoalConfig(),
+        root=root, model="mock", episodes=2,
+    )
+    first = run(cfg)
+    harness = root / "harness"
+
+    assert first.episodes_complete == 1 and first.error == "provider unavailable"
+    assert completed_episodes(cfg) == 1
+    assert snapshot.head(harness) == snapshot.commit_for_episode(harness, 1)
+
+    second = run(cfg, start=1, resume=True)
+    assert second.episodes_complete == 2 and not second.error
+    assert (harness / "FIXED").read_text() == "yes\n"
+
+
+def test_staged_viability_candidate_survives_process_resume(tmp_path):
+    from proteus.adapters.minimal import MinimalHarness
+    from proteus.core import EpisodeResult, GoalConfig, NEUTRAL
+    from proteus.core.episode import RunConfig, pending_candidate_path, run
+
+    class RepairHarness(MinimalHarness):
+        staged_activation = True
+
+        def run_episode(self, spec):
+            active = Path(spec.active_root)
+            candidate = spec.root / "harness"
+            assert not (active / "BROKEN").exists()
+            if spec.episode == 1:
+                (candidate / "BROKEN").write_text("bad build\n")
+            else:
+                assert (candidate / "BROKEN").read_text() == "bad build\n"
+                (candidate / "BROKEN").unlink()
+                (candidate / "FIXED").write_text("yes\n")
+            return EpisodeResult(spec.episode, ok=True)
+
+        def validate_candidate(self, harness_root):
+            return "compile failed" if (Path(harness_root) / "BROKEN").exists() else ""
+
+    adapter = RepairHarness()
+    root = tmp_path / "viability-resume"
+    cfg = RunConfig(
+        name="repair", adapter=adapter, disposition=NEUTRAL, goal=GoalConfig(),
+        root=root, model="mock", episodes=1,
+    )
+    first = run(cfg)
+    assert first.episodes_complete == 1 and not first.eval_history[0]["accepted"]
+    assert pending_candidate_path(root).exists()
+
+    cfg.episodes = 2
+    second = run(cfg, start=1, resume=True)
+    assert second.episodes_complete == 2 and second.eval_history[-1]["accepted"]
+    assert (root / "harness" / "FIXED").read_text() == "yes\n"
+    assert not pending_candidate_path(root).exists()
+
+
+def test_staged_sigkill_candidate_is_captured_before_episode_zero_reset(tmp_path):
+    from proteus.adapters.minimal import MinimalHarness
+    from proteus.core import EpisodeResult, GoalConfig, NEUTRAL
+    from proteus.core.episode import RunConfig, run
+
+    class CrashRecoveryHarness(MinimalHarness):
+        staged_activation = True
+
+        def run_episode(self, spec):
+            active = Path(spec.active_root)
+            candidate = spec.root / "harness"
+            assert not (active / "CRASH_PARTIAL.md").exists()
+            assert (candidate / "CRASH_PARTIAL.md").read_text() == "half written\n"
+            (candidate / "CRASH_PARTIAL.md").write_text("recovered\n")
+            return EpisodeResult(spec.episode, ok=True)
+
+    adapter = CrashRecoveryHarness()
+    root = tmp_path / "sigkill-staged"
+    cfg = RunConfig(
+        name="sigkill", adapter=adapter, disposition=NEUTRAL, goal=GoalConfig(),
+        root=root, model="mock", episodes=0,
+    )
+    assert run(cfg).episodes_complete == 0
+    (root / "harness" / "CRASH_PARTIAL.md").write_text("half written\n")
+
+    cfg.episodes = 1
+    resumed = run(cfg, start=0, resume=True)
+    assert resumed.episodes_complete == 1 and not resumed.error
+    assert (root / "harness" / "CRASH_PARTIAL.md").read_text() == "recovered\n"
 
 
 def test_retried_incomplete_episode_keeps_each_failed_candidate(tmp_path):


### PR DESCRIPTION
Follow-up release blocker for v0.2.0. Failed staged candidates now remain non-executable but become the exact writable repair base for the next attempt or episode. The last-valid runtime and gapless checkpoint chain remain intact across viability failures, provider failures, retries, process resume, and episode-zero recovery. Includes regression coverage and updates the episode contract and v0.2.0 notes.