### PR TITLE
fix: keep the wheel's top level proteus-only

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -31,7 +31,7 @@ code that path imports.
 ## Adding a harness adapter
 
 An adapter is one class implementing seven methods (see the fully-commented
-[`examples/adapter_template.py`](examples/adapter_template.py) and the contract in
+[`proteus/examples/adapter_template.py`](proteus/examples/adapter_template.py) and the contract in
 [`proteus/core/adapter.py`](proteus/core/adapter.py)). The framework handles episodes,
 snapshots, dispositions, goals, and measurement; you provide the harness-specific glue.
 
@@ -91,7 +91,7 @@ and [`environments/README.md`](environments/README.md).
 
 A benchmark is a `BenchTask`: goal text, a `setup(ws)` that seeds the task workspace, and
 a `grade(ws)` that returns an `EvalResult`. See
-[`examples/benchmark_template.py`](examples/benchmark_template.py), the contract in
+[`proteus/examples/benchmark_template.py`](proteus/examples/benchmark_template.py), the contract in
 [`proteus/bench/task.py`](proteus/bench/task.py), and the shipped
 [`proteus/bench/local.py`](proteus/bench/local.py) / `polyglot.py` / `swe.py`.
 
@@ -111,7 +111,7 @@ a `grade(ws)` that returns an `EvalResult`. See
    > the agent's code through [`proteus/bench/sandbox.py`](proteus/bench/sandbox.py)
    > (`run_python`), which never falls back to host Python — this is what `local.py` and
    > `polyglot.py` do. A plain host `subprocess` is acceptable only for a trusted, local
-   > benchmark; see the note in `examples/benchmark_template.py`.
+   > benchmark; see the note in `proteus/examples/benchmark_template.py`.
 
 3. **Wire and test.** `as_goal(TASK)` conditions a run on the task; `as_evaluator(TASK)`
    scores without conditioning. Add a small grader test (solved → `1.0`, empty → `0.0`)

--- a/README.md
+++ b/README.md
@@ -220,7 +220,7 @@ proteus run   --harness mypkg.theirs_adapter:TheirsHarness --arm neutral ...
 round-trip, snapshot-ability, trace shape). The full guide: [docs/ADAPTERS.md](docs/ADAPTERS.md).
 To start from a working skeleton instead of a blank file,
 `python -m proteus.scaffold adapter MyHarness` copies the fully-commented
-[examples/adapter_template.py](examples/adapter_template.py) — see
+[proteus/examples/adapter_template.py](proteus/examples/adapter_template.py) — see
 [CONTRIBUTING.md](CONTRIBUTING.md). The templates ship on PyPI too; outside a Git checkout
 the default output is the current directory (or choose an explicit `--dest`).
 

--- a/examples/__init__.py
+++ b/examples/__init__.py
@@ -1,6 +1,0 @@
-"""Shipped contributor templates and runnable Proteus examples.
-
-The package marker is intentional: setuptools includes this directory in both the wheel
-and source distribution, so ``python -m proteus.scaffold`` has the same templates after a
-PyPI install as it does in a Git checkout.
-"""

--- a/proteus/examples/__init__.py
+++ b/proteus/examples/__init__.py
@@ -1,0 +1,7 @@
+"""Shipped contributor templates and runnable Proteus examples.
+
+Living inside the ``proteus`` package keeps the wheel's top level clean — installing
+proteus-evolve must never claim a generic name like ``examples`` in site-packages — while
+``python -m proteus.scaffold`` still finds the same templates after a PyPI install as in
+a Git checkout.
+"""

--- a/proteus/examples/adapter_template.py
+++ b/proteus/examples/adapter_template.py
@@ -4,7 +4,7 @@ Copy this file to `proteus/adapters/<yourname>.py` (or scaffold it with
 `python -m proteus.scaffold adapter <YourName>`), then work through the TODOs. When it
 passes
 
-    proteus check --harness examples.adapter_template:TemplateHarness --episode
+    proteus check --harness proteus.examples.adapter_template:TemplateHarness --episode
 
 your harness satisfies the whole `HarnessAdapter` contract and Proteus can evolve,
 measure, and swap dispositions in and out of it. Register a short name for it in

--- a/proteus/examples/benchmark_template.py
+++ b/proteus/examples/benchmark_template.py
@@ -8,7 +8,7 @@ to score without conditioning. `proteus.bench.local` / `polyglot` / `swe` are th
 instances; this is the smallest one that shows the whole shape.
 
     python -m proteus.scaffold benchmark <yourname>   # copy + rename this file
-    python examples/benchmark_template.py             # run the demo below, offline
+    python -m proteus.examples.benchmark_template             # run the demo below, offline
 
 The task workspace (`<run>/task/`) lives OUTSIDE the harness snapshot on purpose: it is
 the exercise, not the subject — it moves only forward, and selection rolls back the

--- a/proteus/examples/no_goal_vs_review.py
+++ b/proteus/examples/no_goal_vs_review.py
@@ -1,6 +1,6 @@
 """No-goal self-evolution under three action preferences, measured with one ruler.
 
-    python examples/no_goal_vs_review.py
+    python -m proteus.examples.no_goal_vs_review
 
 Runs the offline `minimal` harness under neutral / review-notes / review-tools with no goal,
 then prints the structural (what got built) and behavioural (R) measurements. This is the

--- a/proteus/scaffold.py
+++ b/proteus/scaffold.py
@@ -4,9 +4,10 @@
     python -m proteus.scaffold benchmark my_task           # -> proteus/bench/my_task.py
     python -m proteus.scaffold adapter MyHarness --dest path/to/file.py
 
-The single source of truth for each skeleton is `examples/adapter_template.py` /
-`examples/benchmark_template.py` — this command copies one and renames the sentinel
-identifiers so `proteus check` (adapter) or the grader (benchmark) works immediately.
+The single source of truth for each skeleton is `proteus/examples/adapter_template.py` /
+`proteus/examples/benchmark_template.py` — this command copies one and renames the
+sentinel identifiers so `proteus check` (adapter) or the grader (benchmark) works
+immediately.
 The templates ship in both the wheel and source distribution. In a Git checkout the
 default destination is the matching `proteus/adapters/` or `proteus/bench/` directory;
 after a regular PyPI install it is the current directory, unless `--dest` is supplied.
@@ -21,9 +22,15 @@ from pathlib import Path
 
 
 def _repo_root() -> Path:
-    # proteus/ and the shipped examples/ package are siblings in both a source checkout
-    # and an unpacked wheel installation.
+    # proteus/ is a direct child of the repo root in a source checkout; in an installed
+    # wheel this is site-packages, which only the default-destination logic cares about.
     return Path(__file__).resolve().parent.parent
+
+
+def _templates_dir() -> Path:
+    # Templates live inside the package, so the same path works from a Git checkout and
+    # from an installed wheel/sdist — and the wheel's top level stays proteus-only.
+    return Path(__file__).resolve().parent / "examples"
 
 
 def _source_checkout() -> bool:
@@ -45,10 +52,10 @@ def scaffold_adapter(name: str, dest: Path, *, force: bool = False) -> Path:
     cls = name if name.endswith("Harness") else f"{name}Harness"
     short = re.sub(r"Harness$", "", cls)
     short = re.sub(r"(?<!^)(?=[A-Z])", "_", short).lower()  # CamelCase -> snake_case
-    template = _repo_root() / "examples" / "adapter_template.py"
+    template = _templates_dir() / "adapter_template.py"
     subs = {
         "TemplateHarness": cls,
-        "examples.adapter_template": _dest_module(dest),
+        "proteus.examples.adapter_template": _dest_module(dest),
         'name = "template"': f'name = "{short}"',
     }
     return _render(template, dest, subs, force=force)
@@ -57,9 +64,9 @@ def scaffold_adapter(name: str, dest: Path, *, force: bool = False) -> Path:
 def scaffold_benchmark(name: str, dest: Path, *, force: bool = False) -> Path:
     """Write a new benchmark (`BenchTask`) skeleton identified by `name` to `dest`."""
     ident = re.sub(r"[^0-9a-zA-Z_-]", "-", name)
-    template = _repo_root() / "examples" / "benchmark_template.py"
+    template = _templates_dir() / "benchmark_template.py"
     subs = {
-        "examples.benchmark_template": _dest_module(dest),
+        "proteus.examples.benchmark_template": _dest_module(dest),
         '"template-add"': f'"{ident}"',
         "name=\"template-add\"": f'name="{ident}"',
     }
@@ -69,7 +76,7 @@ def scaffold_benchmark(name: str, dest: Path, *, force: bool = False) -> Path:
 def _render(template: Path, dest: Path, subs: dict[str, str], *, force: bool) -> Path:
     if not template.exists():
         raise SystemExit(f"template not found: {template}\n"
-                         "reinstall proteus-evolve; wheels and sdists include examples/.")
+                         "reinstall proteus-evolve; distributions include proteus/examples/.")
     if dest.exists() and not force:
         raise SystemExit(f"{dest} already exists (use --force to overwrite)")
     text = template.read_text(encoding="utf-8")
@@ -85,12 +92,14 @@ def main(argv: list[str] | None = None) -> int:
                                  formatter_class=argparse.RawDescriptionHelpFormatter)
     sub = ap.add_subparsers(dest="kind", required=True)
 
-    a = sub.add_parser("adapter", help="new HarnessAdapter from examples/adapter_template.py")
+    a = sub.add_parser("adapter",
+                       help="new HarnessAdapter from proteus/examples/adapter_template.py")
     a.add_argument("name", help="class name, e.g. MyHarness (the 'Harness' suffix is optional)")
     a.add_argument("--dest", default="", help="output path (default: proteus/adapters/<name>.py)")
     a.add_argument("--force", action="store_true", help="overwrite an existing file")
 
-    b = sub.add_parser("benchmark", help="new BenchTask from examples/benchmark_template.py")
+    b = sub.add_parser("benchmark",
+                       help="new BenchTask from proteus/examples/benchmark_template.py")
     b.add_argument("name", help="benchmark id, e.g. my_task")
     b.add_argument("--dest", default="", help="output path (default: proteus/bench/<name>.py)")
     b.add_argument("--force", action="store_true", help="overwrite an existing file")

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -42,7 +42,7 @@ dev = ["pytest>=7.0", "ruff==0.14.14"]
 proteus = "proteus.cli:main"
 
 [tool.setuptools.packages.find]
-include = ["proteus*", "examples*"]
+include = ["proteus*"]
 namespaces = false  # do not crawl large run artefacts as implicit namespace packages
 
 [tool.setuptools.dynamic]

--- a/tests/test_conformance.py
+++ b/tests/test_conformance.py
@@ -3,8 +3,8 @@
 Every built-in adapter that runs without Docker or a model is checked here against the
 whole `HarnessAdapter` contract (`proteus.testing.check_adapter`), so a change that
 breaks the contract fails CI. The committed templates and the scaffolder are checked the
-same way, so `examples/adapter_template.py` and `python -m proteus.scaffold` can never
-silently rot.
+same way, so `proteus/examples/adapter_template.py` and `python -m proteus.scaffold` can
+never silently rot.
 
 Contributors: this is the suite to point at your own adapter. Either register it in
 `proteus/cli.py::_adapter_factory` and add its name to `PURE_ADAPTERS` (if it runs
@@ -22,16 +22,11 @@ from __future__ import annotations
 import importlib
 import importlib.util
 import os
-import sys
 from pathlib import Path
 
 import pytest
 
-_REPO_ROOT = Path(__file__).resolve().parent.parent
-if str(_REPO_ROOT) not in sys.path:
-    sys.path.insert(0, str(_REPO_ROOT))  # make the un-installed examples/ importable
-
-from proteus.testing import check_adapter  # noqa: E402
+from proteus.testing import check_adapter
 
 
 def _load(name: str):
@@ -42,11 +37,11 @@ def _load(name: str):
 
 # Adapters that provision offline (no Docker, no model): the always-on CI gate. Names
 # resolve through the same factory `proteus check --harness` uses.
-PURE_ADAPTERS = ["minimal", "llm", "examples.adapter_template:TemplateHarness"]
+PURE_ADAPTERS = ["minimal", "llm", "proteus.examples.adapter_template:TemplateHarness"]
 
 # Of those, the ones whose loop also runs a full episode offline (so `--episode` works
 # with no API key). `llm` needs a model, so it is provisioning-only above.
-OFFLINE_EPISODE_ADAPTERS = ["minimal", "examples.adapter_template:TemplateHarness"]
+OFFLINE_EPISODE_ADAPTERS = ["minimal", "proteus.examples.adapter_template:TemplateHarness"]
 
 
 @pytest.mark.parametrize("name", PURE_ADAPTERS)
@@ -64,7 +59,7 @@ def test_offline_episode_conformance(name):
 # --- benchmark contract -----------------------------------------------------------------
 
 def _bench_template():
-    return importlib.import_module("examples.benchmark_template")
+    return importlib.import_module("proteus.examples.benchmark_template")
 
 
 def test_benchmark_template_grades():


### PR DESCRIPTION
## What

`pip install proteus-evolve` (since #8) claimed the generic top-level name `examples` in site-packages — collision-prone with any other distribution or user project shipping `examples`, and flagged by wheel-hygiene tools. Since the 0.2.0 version number can never be re-uploaded to PyPI, this must land before the tag.

- Move `examples/{adapter_template,benchmark_template,no_goal_vs_review}.py` into **`proteus/examples/`** — one import name (`proteus.examples.*`) that works identically from a Git checkout and an installed wheel/sdist.
- `proteus/scaffold.py`: templates resolve package-relatively (`_templates_dir()`); sentinel renames and help text updated.
- `pyproject.toml`: distribution manifest back to `include = ["proteus*"]`.
- `tests/test_conformance.py`: adapter names → `proteus.examples.…`; the repo-root `sys.path` hack is gone (no longer needed).
- README / CONTRIBUTING / ROADMAP references updated.

## Verified (local, Python 3.10.13, rebased on #9)

- `ruff check .` clean; `pytest tests/ -q` → **118 passed, 1 skipped**; offline runner 102 passed
- Wheel built: top level is **exactly** `proteus/` + dist-info (asserted)
- Fresh venv outside the checkout: `pip install *.whl` → `python -m proteus.scaffold adapter SmokeHarness` → `proteus check --harness smoke:SmokeHarness --episode` → 0 failures

🤖 Generated with [Claude Code](https://claude.com/claude-code)