### PR TITLE
fix(smoke): find dist cache across adapter state dirs

### DIFF
--- a/scripts/smoke_check.py
+++ b/scripts/smoke_check.py
@@ -155,15 +155,24 @@ def main() -> int:
                       "no src/ change between episode 0 and the second-to-last snapshot")
                 # 2) machine evidence the edited source was rebuilt and booted: the boot
                 # wrapper writes a dist cache tar only when it builds a non-pristine
-                # source, and a boot right now must hit that cache rather than rebuild
-                state = next((d for d in run_root.iterdir()
-                              if d.is_dir() and d.name.endswith("-state")), None)
-                tars_before = set(state.glob("dist-*.tar")) if state else set()
+                # source, and a boot right now must hit that cache rather than rebuild.
+                # Since v0.2.0 framework continuity adds `.proteus-state` beside the
+                # adapter's own `*-state` dir, and iterdir() order is arbitrary — union
+                # the glob over every adapter state dir instead of trusting `next()`.
+                state_dirs = [d for d in run_root.iterdir()
+                              if d.is_dir() and d.name.endswith("-state")
+                              and d.name != ".proteus-state"]
+
+                def _dist_tars() -> set:
+                    return {t for d in state_dirs for t in d.glob("dist-*.tar")}
+
+                tars_before = _dist_tars()
                 check(bool(tars_before),
-                      "a rebuild happened during the run (dist cache exists)")
+                      "a rebuild happened during the run (dist cache exists)",
+                      f"no dist-*.tar under {[d.name for d in state_dirs]}")
                 boot_msg = adapter.check_boot(run_root / "harness")
-                tars_after = set(state.glob("dist-*.tar")) if state else set()
-                check(boot_msg == "" and tars_after == tars_before,
+                tars_after = _dist_tars()
+                check(boot_msg == "" and bool(tars_before) and tars_after == tars_before,
                       "booting the final source hits the cache (it was built and "
                       "loaded during the run)",
                       boot_msg or f"new tars: {[t.name for t in tars_after - tars_before]}")


### PR DESCRIPTION
## What

Both `container (dsh)` and `container (pi)` release-smoke jobs on the v0.2.0 tag failed the same single check — `a rebuild happened during the run (dist cache exists)` — while **every functional check passed** (real `src/` edit in the snapshot chain, evolved self-code boots, planted-error gate works).

Root cause: since v0.2.0, framework continuity creates **`.proteus-state`** beside the adapter's own `.dsh-state`/`.pi-state` in the run root (`proteus/core/continuity.py:123`; dsh/pi declare `continuity_mode = "framework"`). `smoke_check.py` picked its state dir with `next(iterdir() … endswith("-state"))` — `iterdir()` order is arbitrary, and on the CI runners it returned `.proteus-state`, which never holds `dist-*.tar`. The rebuild check failed vacuously, and the follow-up cache-hit check *passed* vacuously (`∅ == ∅`).

## Fix

- Union the `dist-*.tar` glob over **every** adapter `*-state` dir, explicitly excluding `.proteus-state` — no ordering dependence.
- Harden the cache-hit check with `bool(tars_before)` so it can never pass on an empty set again.
- Failure detail now names the searched dirs.

Gate-script only — no runtime code changed. Verified: ruff clean; simulated run-root with both state dirs reproduces the old failure and passes with the fix.

After merge: re-point the v0.2.0 tag at the new HEAD (the tag was never consumed — no GitHub Release was published, so publish.yml/PyPI never fired) and let release-smoke re-run.

🤖 Generated with [Claude Code](https://claude.com/claude-code)