### PR TITLE
Add phase-aware episode budget protocol

### DIFF
--- a/README.md
+++ b/README.md
@@ -276,8 +276,9 @@ roots, so the evolving agent can never read its own condition.
 `v0.2.0` (research preview). Working today: the offline `minimal` harness; the live `llm`
 harness; pinned, source-evolving DeepSeek Harness and Pi adapters with frozen per-episode
 activation, automatic rollback, exact-tree boundary gates, rebuild caching, turn budgets,
-and task mounts; the Aki research adapter;
-local, Polyglot, and SWE-bench task integrations; resume-safe sweeps; the full measurement,
+phase-aware act-priority budget plans and agent-authored checkpoint tracking, and task
+mounts; the Aki research adapter; local, Polyglot, and SWE-bench task integrations;
+resume-safe sweeps; the full measurement,
 audit, reliability, report, and repository-export paths; and adapter/environment tooling.
 CI covers Python 3.10–3.14. The separate release-smoke workflow runs two episodes across
 the public release set (`minimal`, `llm`, `dsh`, `pi`), exercises the benchmark path, and

--- a/docs/ADAPTERS.md
+++ b/docs/ADAPTERS.md
@@ -123,6 +123,32 @@ archives `handoffs/epNNN/<phase>.{json,md}`, carries reflect into the next episo
 falls back to normalized tool names and paths after an interruption. Never persist raw
 model reasoning or tool results. DSH and Pi are the reference integrations.
 
+Every adapter receives the same optional phase-aware budget fields in `EpisodeSpec`.
+Use the core helpers rather than reproducing allocation arithmetic inside the adapter:
+
+```python
+from proteus.core.budget import PHASES, budget_plan, phase_prompt
+
+plan = budget_plan(spec)
+used = 0
+for phase in PHASES:
+    if plan.enabled and used >= plan.hard_limit:
+        break
+    stop_at = plan.stop_at(phase, used)
+    prompt = phase_prompt(spec, phase, used)
+    # Run the native phase with `prompt`; stop its native call loop at `stop_at`.
+    # Refresh `used` from the native trace before starting the next phase.
+```
+
+`budget_plan` preserves legacy `max_turns` / `min_turns_per_phase` behavior and validates
+the explicit normal plan, hard ceiling, act-priority borrowing, and checkpoint reserve.
+`phase_prompt` adds live used/remaining values only when `announce_budget` is part of the
+condition. For an external process, enforce the cumulative stop both between phases and
+by watching its native log during a phase. The adapter defines what one native call is,
+but must use the same definition for stopping, `EpisodeResult.turns`, and trace counters.
+Do not implement checkpointing by synthesizing semantic memory: a framework-continuity
+adapter archives the agent-written handoff and reports a miss when it remains unchanged.
+
 ### 5. Fingerprint
 `disposition_fingerprint` hashes the currently-installed disposition carrier. The core
 records the initial value and every candidate/checkpoint value outside the run root, so F
@@ -167,6 +193,8 @@ but the adapter still owns how the harness sees files.
 - [ ] surfaces declared as data (or established by convention in `seed`)
 - [ ] disposition install is removable — `proteus check` passes
 - [ ] trace parsed from the harness's own logs into `ActionEvent`s
+- [ ] budget-aware loop consumes `budget_plan(spec)`, shows `phase_prompt(...)`, and
+      enforces the returned cumulative stop using the same call unit as its trace
 - [ ] continuity mode declared when not native; framework state remains outside the
       harness snapshot
 - [ ] self-code adapter declares `staged_activation`; every phase uses the same read-only

--- a/docs/ENVIRONMENTS.md
+++ b/docs/ENVIRONMENTS.md
@@ -130,9 +130,18 @@ The episode budget and wall-clock backstop are independent:
   container at the budget line. `--min-turns-per-phase` reserves budget for later phases;
   `--announce-budget` additionally tells the agent the limit, an off-by-default
   experimental condition. Budget stops record `turn_capped` and snapshot normally.
+- For long source-evolution tasks, `--phase-turns` replaces the uniform minimum with an
+  exact normal plan, `--hard-max-turns` adds a bounded burst ceiling, and unused early
+  quota is reserved for act. `--checkpoint-turns` keeps an agent-visible tail for its own
+  persistent handoff and requires `--announce-budget`. A recommended starting point is
+  `300` normal / `500` hard with
+  `observe=40,propose=25,act=200,reflect=35` and a two-call checkpoint reserve. These are
+  experimental-condition fields and must be repeated unchanged when resuming.
 - `--phase-timeout` is wall-clock seconds per phase for containerised harnesses, where the
   external CLI owns its own loop. Reaching it ends the episode with a timeout error rather
   than hanging the sweep. Default 600.
 
 Episode cost grows with episode index — later episodes wake up to a larger harness and read
 more of it — so a cap that is comfortable at episode 1 is the one that matters at episode 30.
+The hard limit is still a ceiling, not a target: a phase may stop early when it has enough
+evidence or a complete change.

--- a/docs/EPISODE.md
+++ b/docs/EPISODE.md
@@ -1,6 +1,7 @@
 # The episode: what updates when, and who owns it
 
 Code: [`proteus/core/episode.py`](../proteus/core/episode.py) (the loop),
+[`proteus/core/budget.py`](../proteus/core/budget.py) (budget protocol),
 [`proteus/core/continuity.py`](../proteus/core/continuity.py) (phase handoffs),
 [`proteus/core/goal.py`](../proteus/core/goal.py) (goals and evaluators),
 [`proteus/core/snapshot.py`](../proteus/core/snapshot.py) (snapshots),
@@ -97,12 +98,12 @@ mount prevents the subject from modifying the frozen runtime through an alias pa
 ### 3. Run the episode — the adapter's core
 
 `adapter.run_episode(spec)`, where spec carries the run root, episode number, model, the
-four phase prompts, `max_turns`, and the seed. *How* the phases execute is entirely the
+four phase prompts, budget plan, and seed. *How* the phases execute is entirely the
 adapter's:
 
 - **minimal / llm** (in-process): the four phases run in the framework process, one
-  JSONL trace line per step; `max_turns` is a **hard cap** — stop cleanly, finish the
-  episode;
+  JSONL trace line per step; the effective budget plan is enforced directly — stop
+  cleanly, finish the episode;
 - **dsh / pi** (external CLI): each phase boots a **fresh container**, but all four boot
   the same last-valid source. The private active snapshot mounts read-only at `/workspace`;
   the writable `root/harness` candidate mounts at `/workspace/candidate`; native state is
@@ -114,19 +115,62 @@ adapter's:
   summary is archived. A budget or timeout stop falls back to normalized tool names and
   paths, never raw reasoning or tool results. History lives under
   `.proteus-state/handoffs/epNNN/`, and reflect carries into the next episode.
-  `max_turns` is enforced in two layers, both harness-agnostic: **exactly
+  The effective hard limit is enforced in two layers, both harness-agnostic: **exactly
   between phases** (no new phase once the budget is spent) and **approximately
   mid-phase** (the session log is polled live — pi's is plain JSONL, dsh's flushes one
   zstd frame per event — and the container is stopped when the count crosses the
-  budget). `min_turns_per_phase` additionally reserves turns for later phases: while
-  phase i runs, its stop line is `max_turns - min_turns_per_phase x phases_after_i`, and
-  reaching the line ends the phase, not the episode — so a greedy observe cannot starve
-  act. A budget stop records `turn_capped`, not an error: files already written
+  budget). The legacy `min_turns_per_phase` additionally reserves turns for later phases:
+  while phase i runs, its stop line is
+  `max_turns - min_turns_per_phase x phases_after_i`, and reaching the line ends the phase,
+  not the episode — so a greedy observe cannot starve act. A budget stop records
+  `turn_capped`, not an error: files already written
   persist, the episode snapshots normally, the run continues. `phase_timeout_s` remains
   the wall-clock backstop. With `announce_budget`, the agent is also *told* its budget
   in every phase prompt, so it can plan within it — off by default, because announcing
-  changes behaviour, and recorded in the manifest;
+  changes behaviour, and recorded in the manifest. The phase-aware protocol below is the
+  recommended configuration for longer source-evolution work.
 - **aki**: delegates the episode to Aki's own supervisor.
+
+#### Phase-aware budget protocol v1
+
+`max_turns` remains the **normal planned budget**, so existing configurations retain their
+meaning. An optional explicit plan adds three knobs:
+
+```bash
+--max-turns 300 \
+--phase-turns observe=40,propose=25,act=200,reflect=35 \
+--hard-max-turns 500 \
+--checkpoint-turns 2 \
+--announce-budget
+```
+
+- The four `--phase-turns` values must name every phase, sum exactly to `--max-turns`,
+  and cannot be combined with `--min-turns-per-phase`.
+- Observe and propose may spend only their own planned allowance. If either stops early,
+  its unused calls remain in the pool instead of being consumed by the next planning
+  phase.
+- Act is the borrowing phase: it receives unused observe/propose calls and may use the
+  difference between the normal 300-call plan and the 500-call hard ceiling. Reflect's
+  planned 35 calls stay protected. With full early phases the cumulative stop lines are
+  40, 65, 465, and 500; if an early phase stops short, act receives the difference.
+- At every phase start, bundled budget-aware adapters add the current calls used, hard
+  calls remaining, planned phase allowance, cumulative phase stop, and checkpoint window
+  to that fresh context. The manifest records protocol version, both limits, all four
+  allocations, checkpoint reserve, and `unused_priority: act`; resume locks them as part
+  of the experimental condition.
+- `checkpoint_turns` is an **agent-visible end-of-phase reserve**, not framework-authored
+  memory. With framework continuity, the agent must use it to update
+  `/workspace/.proteus/handoff.md`; Proteus archives that exact text. If it does not,
+  Proteus retains the existing action-only recovery fallback and increments
+  `checkpoint_misses`. It never turns traces or hidden reasoning into a semantic skill,
+  memory, or plan on the harness's behalf.
+
+The hard ceiling is enforcement; the checkpoint window is a protocol the harness must
+honour. An opaque tool loop cannot have an already-executed ordinary call retroactively
+converted into a handoff call, so missed checkpoints are made visible rather than silently
+presented as successful memory. Custom adapters consume the same harness-neutral
+`budget_plan(spec)` and `phase_prompt(spec, phase, used_before)` helpers, then enforce the
+returned cumulative stop in their own native loop.
 
 An exception or `res.ok == False` preserves the partial candidate under
 `refs/proteus/candidates/episode-N-failed`, automatically restores files, index, and HEAD
@@ -245,6 +289,7 @@ evolved memory. Raw conversation and process state never survive.
 | part | where |
 |---|---|
 | phase-prompt assembly rules (where goal / feedback / disposition inject) | `episode._phase_prompts` |
+| phase allocation, hard ceiling, live budget prompt | `budget.py` |
 | framework continuity protocol, redaction, phase history, fallback | `continuity.py` |
 | evaluator timing, visibility, crash degradation, selection | `goal.py` + `episode.run` |
 | snapshots, non-destructive rejection, gapless mapping, no ignore rules | `snapshot.py` |
@@ -280,7 +325,7 @@ evolved memory. Raw conversation and process state never survive.
 | disposition carrier | JSON file | JSON file | `AGENTS.md` block | `AGENTS.md` block | apparatus-native |
 | continuity | none | none | Proteus framework handoff | Proteus framework handoff | native supervisor |
 | self-code | none | none | **real TS source (staged; boundary rebuild)** | **real TS source (staged; boundary rebuild)** | `loop.py` + package copy |
-| iteration bound | `max_turns`, hard | `max_turns`, hard | `max_turns`: exact between phases + mid-phase log watch | `max_turns`: exact between phases + mid-phase log watch | apparatus turn gate |
+| iteration bound | phase plan, direct hard stop | phase plan, direct hard stop | phase plan: exact between phases + mid-phase log watch | phase plan: exact between phases + mid-phase log watch | apparatus turn gate |
 | needs | nothing | API key | Docker + key | Docker + key | the private Aki repo |
 
 ## Failure paths

--- a/docs/RECIPES.md
+++ b/docs/RECIPES.md
@@ -98,6 +98,27 @@ is blocked from activation and restored as the next episode's writable repair ba
 running harness remains the last-valid snapshot. Containers run as the host uid/gid so
 their bind-mounted files remain editable on Linux.
 
+### Long-form source evolution budget
+
+The 32-call commands above are smoke-sized demonstrations. For a substantial source change
+(for example, adding a modality), start with a phase-aware budget so planning cannot consume
+the implementation window and act can expand without making 500 calls the expected cost:
+
+```bash
+proteus run --harness dsh \
+    --goal "Add robust audio-input support and verify it end to end." \
+    --evaluator step@observe --evaluator tool-calls \
+    --arm neutral --seeds 1 --episodes 30 \
+    --max-turns 300 \
+    --phase-turns observe=40,propose=25,act=200,reflect=35 \
+    --hard-max-turns 500 --checkpoint-turns 2 --announce-budget \
+    --out runs/dsh-audio
+```
+
+This does not ask Proteus to invent memory or skills for DSH. Each fresh phase sees its
+live remaining budget; DSH owns the handoff content, while Proteus archives it and reports
+`checkpoint_misses` if DSH leaves the checkpoint unchanged.
+
 ## Watch, measure, audit, resume, and export
 
 These commands are harness-independent:

--- a/proteus/adapters/dsh.py
+++ b/proteus/adapters/dsh.py
@@ -34,9 +34,9 @@ from pathlib import Path
 from typing import Optional, Sequence
 
 from proteus.core.adapter import ActionEvent, EpisodeResult, EpisodeSpec, Surface
+from proteus.core.budget import PHASES, budget_plan, phase_prompt
 from proteus.core.continuity import CONTAINER_ROOT, HandoffStore
 from proteus.core.disposition import Disposition
-from proteus.core.episode import PHASES
 
 IMAGE = os.environ.get("PROTEUS_DSH_IMAGE", "proteus-env-dsh-src:0.1.0-rc.7")
 PHASE_TIMEOUT_S = 600
@@ -327,7 +327,9 @@ class DshHarness:
         mapping: dict[str, list[str]] = {}
         error = ""
         capped = False
-        budget = int(spec.max_turns or 0)
+        checkpoint_misses = 0
+        plan = budget_plan(spec)
+        budget = plan.hard_limit
         episode_dirs: set = set()
         active = Path(spec.active_root) if spec.active_root is not None else harness
         # Core-managed staged episodes already execute a previously validated snapshot.
@@ -347,18 +349,20 @@ class DshHarness:
         workspace_mounts = ((str(active), "/workspace", "ro"),
                             (str(harness), "/workspace/candidate")) \
             if spec.active_root is not None else ((str(harness), "/workspace"),)
-        min_pp = int(getattr(spec, "min_turns_per_phase", 0) or 0)
-        for idx, phase in enumerate(PHASES if not error else ()):
+        for phase in PHASES if not error else ():
             # the budget is enforced twice, both harness-agnostically: exactly, between
             # phases (no new phase once it is spent) and approximately, mid-phase (the
             # session log is polled and the container stopped at the phase's stop line).
-            # The stop line reserves min_turns_per_phase for every later phase, so a
-            # reservation stop moves to the next phase; only a spent budget ends the
+            # BudgetPlan preserves the legacy later-phase reserve or applies the explicit
+            # act-priority plan. A phase stop moves on; only the hard ceiling caps the
             # episode.
-            if budget and self._live_calls(state, episode_dirs, set()) >= budget:
+            used = self._live_calls(state, episode_dirs, set()) if plan.enabled else 0
+            if budget and used >= budget:
                 capped = True
                 break
-            stop_at = budget - min_pp * (len(PHASES) - idx - 1) if budget else 0
+            stop_at = plan.stop_at(phase, used)
+            if budget and used >= stop_at:
+                continue
             handoff_start = handoffs.begin(spec.episode, phase)
             before = self._session_dirs(state)
             fired = [False]
@@ -374,14 +378,14 @@ class DshHarness:
             try:
                 proc = self.sandbox.run(
                     run_root,
-                    ["--profile", "headless", spec.phase_prompts.get(phase, phase)],
+                    ["--profile", "headless", phase_prompt(spec, phase, used)],
                     env={"DEEPSEEK_API_KEY": self.key,
                          "DSH_PERMISSION_MODE": self.permission_mode},
                     timeout_s=self.phase_timeout_s,
                     mounts=workspace_mounts + ((str(state), "/state"),
                             (str(handoffs.root), CONTAINER_ROOT))
                            + self._task_mount(run_root),
-                    stop_check=stop_check if budget else None,
+                    stop_check=stop_check if plan.enabled else None,
                 )
             except subprocess.TimeoutExpired:
                 timed_out = True
@@ -395,8 +399,10 @@ class DshHarness:
                 for session_dir in session_dirs:
                     phase_events.extend(
                         self._session_trace(session_dir, phase, partial=True))
-            handoffs.finish(handoff_start, phase_events,
-                            interrupted=timed_out or fired[0])
+            handoff = handoffs.finish(handoff_start, phase_events,
+                                      interrupted=timed_out or fired[0])
+            if spec.checkpoint_turns and handoff["source"] != "agent":
+                checkpoint_misses += 1
             if timed_out:
                 error = f"phase {phase}: timeout after {self.phase_timeout_s}s"
                 break
@@ -414,10 +420,18 @@ class DshHarness:
         (run_root / "traces" / f"ep{spec.episode:03d}.json").write_text(
             json.dumps(mapping, indent=1))
         trace = self.read_trace(run_root, spec.episode)
+        phase_counts = {
+            phase: sum(1 for event in trace if event.phase == phase and event.tool)
+            for phase in PHASES
+        }
+        counters = {"phases": len(mapping), "turn_capped": capped,
+                    "checkpoint_misses": checkpoint_misses}
+        counters.update({f"phase_{phase}_turns": count
+                         for phase, count in phase_counts.items()})
         return EpisodeResult(
             episode=spec.episode, ok=not error,
             turns=sum(1 for e in trace if e.tool), error=error,
-            counters={"phases": len(mapping), "turn_capped": capped},
+            counters=counters,
         )
 
     def _live_calls(self, state: Path, episode_dirs: set, extra: set) -> int:

--- a/proteus/adapters/llm.py
+++ b/proteus/adapters/llm.py
@@ -26,7 +26,7 @@ from pathlib import Path
 
 from proteus.adapters.minimal import MinimalHarness
 from proteus.core.adapter import EpisodeResult, EpisodeSpec
-from proteus.core.episode import PHASES
+from proteus.core.budget import PHASES, budget_plan, phase_prompt
 
 SYSTEM = """\
 You are an agent that maintains and improves its own harness — the set of files it wakes
@@ -117,21 +117,20 @@ class LLMHarness(MinimalHarness):
         turn = 0
         writes = {"notes": 0, "tools": 0}
         tokens_in = tokens_out = 0
+        phase_counts = {phase: 0 for phase in PHASES}
         error = ""
         capped = False
-        min_pp = int(getattr(spec, "min_turns_per_phase", 0) or 0)
+        plan = budget_plan(spec)
         with trace_path.open("w", encoding="utf-8") as sink:
-            for idx, phase in enumerate(PHASES):
-                # `max_turns` bounds the whole episode, model calls included; the phase
-                # stop line additionally reserves min_turns_per_phase for later phases,
-                # and reaching it ends the phase, not the episode
-                if spec.max_turns and turn >= spec.max_turns:
+            for phase in PHASES:
+                if plan.enabled and turn >= plan.hard_limit:
                     capped = True
                 if capped:
                     break
-                stop_at = (spec.max_turns - min_pp * (len(PHASES) - idx - 1)
-                           if spec.max_turns else 0)
-                prompt = spec.phase_prompts.get(phase, "")
+                stop_at = plan.stop_at(phase, turn)
+                if plan.enabled and turn >= stop_at:
+                    continue
+                prompt = phase_prompt(spec, phase, turn)
                 user = (f"Episode {spec.episode}, phase: {phase}.\n\n"
                         f"{prompt}\n\nCurrent harness state:\n{_render_state(harness)}")
                 try:
@@ -144,11 +143,12 @@ class LLMHarness(MinimalHarness):
                 tokens_in += int(usage.get("prompt_tokens") or 0)
                 tokens_out += int(usage.get("completion_tokens") or 0)
                 turn += 1
+                phase_counts[phase] += 1
                 sink.write(json.dumps({"turn": turn, "phase": phase, "tool": None,
                                        "surface": None, "text": reply[:500]}) + "\n")
                 for act in _parse_actions(reply):
-                    if spec.max_turns and turn >= stop_at:
-                        capped = turn >= spec.max_turns
+                    if plan.enabled and turn >= stop_at:
+                        capped = turn >= plan.hard_limit
                         break
                     tool = act.get("tool", "")
                     name = "".join(c for c in str(act.get("name", "unnamed"))
@@ -165,8 +165,12 @@ class LLMHarness(MinimalHarness):
                         surface = "tools"
                     else:
                         continue
+                    phase_counts[phase] += 1
                     sink.write(json.dumps({"turn": turn, "phase": phase, "tool": tool,
                                            "surface": surface, "text": name}) + "\n")
+        counters = {"writes": writes, "turn_capped": capped,
+                    "tokens_in": tokens_in, "tokens_out": tokens_out}
+        counters.update({f"phase_{phase}_turns": count
+                         for phase, count in phase_counts.items()})
         return EpisodeResult(episode=spec.episode, ok=not error, turns=turn, error=error,
-                             counters={"writes": writes, "turn_capped": capped,
-                                       "tokens_in": tokens_in, "tokens_out": tokens_out})
+                             counters=counters)

--- a/proteus/adapters/minimal.py
+++ b/proteus/adapters/minimal.py
@@ -19,8 +19,8 @@ from pathlib import Path
 from typing import Callable, Optional, Sequence, Tuple
 
 from proteus.core.adapter import ActionEvent, EpisodeResult, EpisodeSpec, Surface
+from proteus.core.budget import PHASES, budget_plan, phase_prompt
 from proteus.core.disposition import Disposition
-from proteus.core.episode import PHASES
 
 # A policy maps (phase, prompt, episode, rng) -> list of (tool, surface, text) actions.
 Action = Tuple[str, Optional[str], str]
@@ -94,22 +94,23 @@ class MinimalHarness:
         trace_path.parent.mkdir(parents=True, exist_ok=True)
         turn = 0
         writes = {"notes": 0, "tools": 0}
+        phase_counts = {phase: 0 for phase in PHASES}
         capped = False
-        min_pp = int(getattr(spec, "min_turns_per_phase", 0) or 0)
+        plan = budget_plan(spec)
         with trace_path.open("w", encoding="utf-8") as sink:
-            for idx, phase in enumerate(PHASES):
+            for phase in PHASES:
+                if plan.enabled and turn >= plan.hard_limit:
+                    capped = True
                 if capped:
                     break
-                # the phase's stop line reserves min_turns_per_phase for every later
-                # phase; reaching it ends THIS phase, only a spent budget ends the episode
-                stop_at = (spec.max_turns - min_pp * (len(PHASES) - idx - 1)
-                           if spec.max_turns else 0)
-                prompt = spec.phase_prompts.get(phase, "")
+                stop_at = plan.stop_at(phase, turn)
+                prompt = phase_prompt(spec, phase, turn)
                 for tool, surface, text in self.policy(phase, prompt, spec.episode, rng):
-                    if spec.max_turns and turn >= stop_at:
-                        capped = turn >= spec.max_turns
+                    if plan.enabled and turn >= stop_at:
+                        capped = turn >= plan.hard_limit
                         break
                     turn += 1
+                    phase_counts[phase] += 1
                     if tool == "write_note":
                         (harness / "notes" / f"{text}.md").write_text(
                             f"episode {spec.episode}: {text}\n")
@@ -122,8 +123,10 @@ class MinimalHarness:
                         "turn": turn, "phase": phase, "tool": tool,
                         "surface": surface, "text": text,
                     }) + "\n")
-        return EpisodeResult(episode=spec.episode, ok=True, turns=turn,
-                             counters={"writes": writes, "turn_capped": capped})
+        counters = {"writes": writes, "turn_capped": capped}
+        counters.update({f"phase_{phase}_turns": count
+                         for phase, count in phase_counts.items()})
+        return EpisodeResult(episode=spec.episode, ok=True, turns=turn, counters=counters)
 
     def read_trace(self, root: Path, episode: int) -> Sequence[ActionEvent]:
         path = root / "traces" / f"ep{episode:03d}.jsonl"

--- a/proteus/adapters/pi.py
+++ b/proteus/adapters/pi.py
@@ -27,9 +27,9 @@ from typing import Optional, Sequence
 
 from proteus.adapters import instructions
 from proteus.core.adapter import ActionEvent, EpisodeResult, EpisodeSpec, Surface
+from proteus.core.budget import PHASES, budget_plan, phase_prompt
 from proteus.core.continuity import CONTAINER_ROOT, HandoffStore
 from proteus.core.disposition import Disposition
-from proteus.core.episode import PHASES
 
 IMAGE = os.environ.get("PROTEUS_PI_IMAGE", "proteus-env-pi-src:0.84.2")
 PHASE_TIMEOUT_S = 600
@@ -234,7 +234,9 @@ class PiHarness:
         mapping: dict[str, list[str]] = {}
         error = ""
         capped = False
-        budget = int(spec.max_turns or 0)
+        checkpoint_misses = 0
+        plan = budget_plan(spec)
+        budget = plan.hard_limit
         episode_files: set = set()
         active = Path(spec.active_root) if spec.active_root is not None else harness
         # Core-managed staged episodes already execute a previously validated snapshot.
@@ -252,18 +254,20 @@ class PiHarness:
         workspace_mounts = ((str(active), "/workspace", "ro"),
                             (str(harness), "/workspace/candidate")) \
             if spec.active_root is not None else ((str(harness), "/workspace"),)
-        min_pp = int(getattr(spec, "min_turns_per_phase", 0) or 0)
-        for idx, phase in enumerate(PHASES if not error else ()):
+        for phase in PHASES if not error else ():
             # the budget is enforced twice, both harness-agnostically: exactly, between
             # phases (no new phase once it is spent) and approximately, mid-phase (the
             # session log is polled and the container stopped at the phase's stop line).
-            # The stop line reserves min_turns_per_phase for every later phase, so a
-            # reservation stop moves to the next phase; only a spent budget ends the
+            # BudgetPlan preserves the legacy later-phase reserve or applies the explicit
+            # act-priority plan. A phase stop moves on; only the hard ceiling caps the
             # episode.
-            if budget and self._live_calls(state, episode_files, set()) >= budget:
+            used = self._live_calls(state, episode_files, set()) if plan.enabled else 0
+            if budget and used >= budget:
                 capped = True
                 break
-            stop_at = budget - min_pp * (len(PHASES) - idx - 1) if budget else 0
+            stop_at = plan.stop_at(phase, used)
+            if budget and used >= stop_at:
+                continue
             handoff_start = handoffs.begin(spec.episode, phase)
             before = self._sessions(state)
             fired = [False]
@@ -281,13 +285,13 @@ class PiHarness:
                     run_root,
                     ["--provider", self.provider, "--model", spec.model or self.model,
                      "--session-dir", "/state", "--skill", "/workspace/skills",
-                     "-p", spec.phase_prompts.get(phase, phase)],
+                     "-p", phase_prompt(spec, phase, used)],
                     env={"DEEPSEEK_API_KEY": self.key},
                     timeout_s=self.phase_timeout_s,
                     mounts=workspace_mounts + ((str(state), "/state"),
                             (str(handoffs.root), CONTAINER_ROOT))
                            + self._task_mount(run_root),
-                    stop_check=stop_check if budget else None,
+                    stop_check=stop_check if plan.enabled else None,
                 )
             except subprocess.TimeoutExpired:
                 timed_out = True
@@ -300,8 +304,10 @@ class PiHarness:
                 episode_files |= new
                 for session_path in session_paths:
                     phase_events.extend(self._session_trace(session_path, phase))
-            handoffs.finish(handoff_start, phase_events,
-                            interrupted=timed_out or fired[0])
+            handoff = handoffs.finish(handoff_start, phase_events,
+                                      interrupted=timed_out or fired[0])
+            if spec.checkpoint_turns and handoff["source"] != "agent":
+                checkpoint_misses += 1
             if timed_out:
                 error = f"phase {phase}: timeout after {self.phase_timeout_s}s"
                 break
@@ -319,10 +325,18 @@ class PiHarness:
         (run_root / "traces" / f"ep{spec.episode:03d}.json").write_text(
             json.dumps(mapping, indent=1))
         trace = self.read_trace(run_root, spec.episode)
+        phase_counts = {
+            phase: sum(1 for event in trace if event.phase == phase and event.tool)
+            for phase in PHASES
+        }
+        counters = {"phases": len(mapping), "turn_capped": capped,
+                    "checkpoint_misses": checkpoint_misses}
+        counters.update({f"phase_{phase}_turns": count
+                         for phase, count in phase_counts.items()})
         return EpisodeResult(
             episode=spec.episode, ok=not error,
             turns=sum(1 for e in trace if e.tool), error=error,
-            counters={"phases": len(mapping), "turn_capped": capped},
+            counters=counters,
         )
 
     def _live_calls(self, state: Path, episode_files: set, extra: set) -> int:

--- a/proteus/cli.py
+++ b/proteus/cli.py
@@ -18,6 +18,7 @@ import sys
 from pathlib import Path
 
 from proteus.core.disposition import NEUTRAL, record, review
+from proteus.core.budget import make_budget_plan
 from proteus.core.goal import GoalConfig
 from proteus.sweep import SweepConfig, run_sweep
 
@@ -139,6 +140,24 @@ def _goal(spec: str, evaluators) -> GoalConfig:
     return GoalConfig.of(text=text, evaluators=evaluators)
 
 
+def _phase_turns(spec: str) -> dict[str, int]:
+    """Parse ``observe=40,propose=25,act=200,reflect=35``."""
+    values: dict[str, int] = {}
+    for item in spec.split(","):
+        name, sep, raw = item.strip().partition("=")
+        if not sep or not name or not raw:
+            raise argparse.ArgumentTypeError(
+                "use observe=N,propose=N,act=N,reflect=N"
+            )
+        if name in values:
+            raise argparse.ArgumentTypeError(f"phase {name!r} appears more than once")
+        try:
+            values[name] = int(raw)
+        except ValueError:
+            raise argparse.ArgumentTypeError(f"phase {name!r} needs an integer") from None
+    return values
+
+
 def _evaluator(spec: str, adapter_factory):
     """Parse one --evaluator: `<what>[@hidden|@observe]`. Returns (spec, task | None).
 
@@ -213,6 +232,18 @@ def cmd_run(args) -> int:
             f"--min-turns-per-phase={args.min_turns_per_phase} across 4 phases; "
             f"use --max-turns >= {required}"
         )
+    try:
+        make_budget_plan(
+            max_turns=args.max_turns,
+            min_turns_per_phase=args.min_turns_per_phase,
+            phase_turns=args.phase_turns,
+            hard_max_turns=args.hard_max_turns,
+            checkpoint_turns=args.checkpoint_turns,
+        )
+    except ValueError as exc:
+        raise SystemExit(str(exc)) from None
+    if args.checkpoint_turns and not args.announce_budget:
+        raise SystemExit("--checkpoint-turns requires --announce-budget")
     factory = _harness_factory(args)
     parsed = [_evaluator(e, factory) for e in (args.evaluator or ())]
     evaluators = tuple(spec for spec, _ in parsed)
@@ -241,6 +272,9 @@ def cmd_run(args) -> int:
             ],
         },
         min_turns_per_phase=args.min_turns_per_phase,
+        phase_turns=args.phase_turns,
+        hard_max_turns=args.hard_max_turns,
+        checkpoint_turns=args.checkpoint_turns,
         announce_budget=args.announce_budget,
         on_existing=args.on_existing,
     )
@@ -455,9 +489,19 @@ def main(argv=None) -> int:
                    help="reserve at least this many turns for every phase: a phase that "
                         "would starve the later ones is ended early (max-turns must be "
                         ">= 4x this)")
+    r.add_argument("--phase-turns", type=_phase_turns, default={}, metavar="PLAN",
+                   help="explicit normal allocation, e.g. "
+                        "observe=40,propose=25,act=200,reflect=35; replaces "
+                        "--min-turns-per-phase and must sum to --max-turns")
+    r.add_argument("--hard-max-turns", type=int, default=0, metavar="N",
+                   help="burst ceiling for --phase-turns (default: --max-turns); unused "
+                        "early quota and burst capacity are prioritised for act")
+    r.add_argument("--checkpoint-turns", type=int, default=0, metavar="N",
+                   help="reserve the final N calls of each planned phase for a persistent "
+                        "handoff; requires --phase-turns and --announce-budget")
     r.add_argument("--announce-budget", action="store_true",
-                   help="tell the agent its per-episode tool-call budget in every phase "
-                        "prompt (recorded in the manifest; announcing changes behaviour)")
+                   help="tell the agent its live used/remaining calls and phase allowance "
+                        "(recorded in the manifest; announcing changes behaviour)")
     r.add_argument("--phase-timeout", type=int, default=0, metavar="S",
                    help="wall-clock limit per phase for containerised harnesses "
                         "(default: the adapter's own, 600s)")

--- a/proteus/core/__init__.py
+++ b/proteus/core/__init__.py
@@ -7,6 +7,7 @@ from proteus.core.adapter import (
 )
 from proteus.core.disposition import NEUTRAL, Disposition, record, review
 from proteus.core.continuity import HandoffStore, PROTOCOL_VERSION
+from proteus.core.budget import BUDGET_PROTOCOL_VERSION, BudgetPlan, budget_plan
 from proteus.core.episode import RunConfig, RunResult, run
 from proteus.core.goal import (
     EvalResult,
@@ -21,6 +22,8 @@ from proteus.core.goal import (
 __all__ = [
     "NEUTRAL",
     "ActionEvent",
+    "BUDGET_PROTOCOL_VERSION",
+    "BudgetPlan",
     "Disposition",
     "EpisodeResult",
     "EpisodeSpec",
@@ -37,6 +40,7 @@ __all__ = [
     "RunResult",
     "Surface",
     "Visibility",
+    "budget_plan",
     "record",
     "review",
     "run",

--- a/proteus/core/adapter.py
+++ b/proteus/core/adapter.py
@@ -77,6 +77,16 @@ class EpisodeSpec:
     line is `max_turns - min_turns_per_phase * phases_remaining_after_i`: a phase that
     reaches its line is ended early so the later phases keep their reserve. A
     reservation stop moves to the next phase; only a spent budget ends the episode."""
+    phase_turns: Mapping[str, int] = field(default_factory=dict)
+    """Optional explicit normal-plan allocation for observe/propose/act/reflect. When
+    present it replaces ``min_turns_per_phase`` and must sum to ``max_turns``."""
+    hard_max_turns: int = 0
+    """Optional burst ceiling for an explicit phase plan. Zero means ``max_turns``."""
+    checkpoint_turns: int = 0
+    """Final calls in each explicit phase allowance reserved by the prompt protocol for
+    a persistent continuation checkpoint."""
+    announce_budget: bool = False
+    """Whether the adapter should show the live budget contract at phase start."""
     seed: int = 0                    # the run's RNG seed (condition replicate index)
     extra_env: Mapping[str, str] = field(default_factory=dict)
     continuity_mode: str = "native"

--- a/proteus/core/budget.py
+++ b/proteus/core/budget.py
@@ -1,0 +1,218 @@
+"""Harness-neutral episode budget planning.
+
+The core records one budget condition and adapters consume the resulting ``BudgetPlan``.
+This keeps allocation policy out of individual harness integrations while leaving the
+adapter responsible for counting and stopping its own native tool loop.
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from typing import Mapping
+
+
+PHASES = ("observe", "propose", "act", "reflect")
+BUDGET_PROTOCOL_VERSION = 1
+
+
+def _integer(name: str, value: object) -> int:
+    if isinstance(value, bool) or not isinstance(value, int):
+        raise ValueError(f"{name} must be an integer, got {value!r}")
+    return value
+
+
+@dataclass(frozen=True)
+class BudgetPlan:
+    """Validated allocation and hard-stop policy for one episode.
+
+    ``normal_limit`` is the planned budget. ``hard_limit`` is a burst ceiling. With an
+    explicit phase allocation, observe and propose receive only their planned allowance;
+    anything they leave unused, plus the burst allowance, is made available to act. The
+    later phases retain their planned reserve. This makes act the only phase that can
+    deliberately borrow from the pool while preserving a bounded reflect phase.
+    """
+
+    normal_limit: int
+    hard_limit: int
+    phase_allowances: Mapping[str, int]
+    min_turns_per_phase: int = 0
+    checkpoint_turns: int = 0
+
+    @property
+    def enabled(self) -> bool:
+        return self.hard_limit > 0
+
+    @property
+    def explicit(self) -> bool:
+        return bool(self.phase_allowances)
+
+    def planned_allowance(self, phase: str) -> int:
+        """Return the phase's normal-plan allowance, or its legacy reserve."""
+        self._phase_index(phase)
+        if self.explicit:
+            return int(self.phase_allowances[phase])
+        return self.min_turns_per_phase
+
+    def stop_at(self, phase: str, used_before: int) -> int:
+        """Cumulative call count at which an adapter must stop this phase.
+
+        A zero return means unbounded. For the explicit protocol, pre-act phases cannot
+        spend each other's unused quota. Act receives the unused quota and the difference
+        between the normal and hard limits. Every other phase stays bounded by its own
+        planned allowance.
+        """
+        idx = self._phase_index(phase)
+        used_before = max(0, int(used_before))
+        if not self.enabled:
+            return 0
+        if not self.explicit:
+            later = len(PHASES) - idx - 1
+            return self.hard_limit - self.min_turns_per_phase * later
+
+        if phase != "act":
+            return min(self.hard_limit, used_before + self.planned_allowance(phase))
+        later_reserve = sum(
+            int(self.phase_allowances[name]) for name in PHASES[idx + 1:]
+        )
+        return max(used_before, self.hard_limit - later_reserve)
+
+    def prompt(self, phase: str, used_before: int, episode: int,
+               continuity_mode: str = "native") -> str:
+        """Render the live phase-start budget contract shown to the subject agent."""
+        stop = self.stop_at(phase, used_before)
+        if not stop:
+            return ""
+        used = max(0, int(used_before))
+        phase_remaining = max(0, stop - used)
+        hard_remaining = max(0, self.hard_limit - used)
+        lines = [
+            f"Proteus budget protocol v{BUDGET_PROTOCOL_VERSION} — episode {episode}, "
+            f"phase {phase}:",
+            f"- calls already used before this phase: {used}",
+            f"- normal episode budget: {self.normal_limit}",
+            f"- episode hard ceiling: {self.hard_limit} ({hard_remaining} remain)",
+            f"- this phase stops at cumulative call {stop} "
+            f"({phase_remaining} calls available now)",
+        ]
+        if self.explicit:
+            lines.insert(4, f"- planned allowance for this phase: "
+                            f"{self.planned_allowance(phase)}")
+        elif self.min_turns_per_phase:
+            lines.insert(4, f"- configured reserve floor per phase: "
+                            f"{self.min_turns_per_phase}")
+        else:
+            lines.insert(4, "- no phase allocation: this phase shares the remaining cap")
+        if self.explicit and phase == "act":
+            burst = self.hard_limit - self.normal_limit
+            lines.append(
+                "- act owns unused earlier-phase allowance"
+                + (f" and up to {burst} burst calls" if burst else "")
+            )
+        if self.checkpoint_turns:
+            checkpoint_at = max(used, stop - self.checkpoint_turns)
+            lines.append(
+                f"- checkpoint reserve: keep final {self.checkpoint_turns} calls unspent; "
+                "before ending (even early), use them to persist a concise continuation "
+                f"checkpoint; cumulative call {checkpoint_at} is the latest ordinary-work "
+                "boundary"
+            )
+            if continuity_mode == "framework":
+                lines.append(
+                    "- checkpoint target: /workspace/.proteus/handoff.md; Proteus will "
+                    "archive what you write but will not invent a semantic summary for you"
+                )
+        return "\n".join(lines)
+
+    @staticmethod
+    def _phase_index(phase: str) -> int:
+        try:
+            return PHASES.index(phase)
+        except ValueError as exc:
+            raise ValueError(f"unknown episode phase {phase!r}") from exc
+
+
+def make_budget_plan(*, max_turns: int, min_turns_per_phase: int = 0,
+                     phase_turns: Mapping[str, int] | None = None,
+                     hard_max_turns: int = 0, checkpoint_turns: int = 0) -> BudgetPlan:
+    """Validate public budget knobs and return their canonical execution plan."""
+    normal = _integer("max_turns", max_turns)
+    minimum = _integer("min_turns_per_phase", min_turns_per_phase)
+    hard_arg = _integer("hard_max_turns", hard_max_turns)
+    checkpoint = _integer("checkpoint_turns", checkpoint_turns)
+    if normal < 0:
+        raise ValueError("max_turns must be 0 (unlimited) or a positive integer")
+    if minimum < 0:
+        raise ValueError("min_turns_per_phase must be 0 or a positive integer")
+    if hard_arg < 0:
+        raise ValueError("hard_max_turns must be 0 or a positive integer")
+    if checkpoint < 0:
+        raise ValueError("checkpoint_turns must be 0 or a positive integer")
+
+    raw = dict(phase_turns or {})
+    if raw:
+        missing = [phase for phase in PHASES if phase not in raw]
+        extra = sorted(repr(key) for key in raw if key not in PHASES)
+        if missing or extra:
+            detail = []
+            if missing:
+                detail.append(f"missing {', '.join(missing)}")
+            if extra:
+                detail.append(f"unknown {', '.join(extra)}")
+            raise ValueError("phase_turns must name observe, propose, act, reflect (" +
+                             "; ".join(detail) + ")")
+        canonical = {phase: _integer(f"phase_turns[{phase}]", raw[phase])
+                     for phase in PHASES}
+        if any(value < 0 for value in canonical.values()):
+            raise ValueError("phase_turns values must be 0 or positive integers")
+        if not normal:
+            raise ValueError("phase_turns requires a positive max_turns normal budget")
+        if sum(canonical.values()) != normal:
+            raise ValueError(
+                f"phase_turns sum to {sum(canonical.values())}, not max_turns={normal}"
+            )
+        if minimum:
+            raise ValueError("phase_turns cannot be combined with min_turns_per_phase")
+        hard = hard_arg or normal
+        if hard < normal:
+            raise ValueError(
+                f"hard_max_turns={hard} must be at least max_turns={normal}"
+            )
+        if checkpoint and checkpoint > min(canonical.values()):
+            raise ValueError(
+                "checkpoint_turns cannot exceed the smallest phase_turns allowance"
+            )
+        return BudgetPlan(normal, hard, canonical, checkpoint_turns=checkpoint)
+
+    if hard_arg:
+        raise ValueError("hard_max_turns requires an explicit phase_turns plan")
+    if checkpoint:
+        raise ValueError("checkpoint_turns requires an explicit phase_turns plan")
+    if normal and minimum * len(PHASES) > normal:
+        raise ValueError(
+            f"max_turns={normal} cannot honour min_turns_per_phase={minimum}: "
+            f"{len(PHASES)} phases need at least {minimum * len(PHASES)} turns"
+        )
+    return BudgetPlan(normal, normal, {}, min_turns_per_phase=minimum)
+
+
+def budget_plan(spec: object) -> BudgetPlan:
+    """Build a plan from an EpisodeSpec-like object (keeps custom adapters simple)."""
+    return make_budget_plan(
+        max_turns=getattr(spec, "max_turns", 0) or 0,
+        min_turns_per_phase=getattr(spec, "min_turns_per_phase", 0) or 0,
+        phase_turns=getattr(spec, "phase_turns", None),
+        hard_max_turns=getattr(spec, "hard_max_turns", 0) or 0,
+        checkpoint_turns=getattr(spec, "checkpoint_turns", 0) or 0,
+    )
+
+
+def phase_prompt(spec: object, phase: str, used_before: int) -> str:
+    """Add a live budget header when this experimental condition announces it."""
+    prompt = str(getattr(spec, "phase_prompts", {}).get(phase, ""))
+    if not bool(getattr(spec, "announce_budget", False)):
+        return prompt
+    note = budget_plan(spec).prompt(
+        phase, used_before, int(getattr(spec, "episode", 0) or 0),
+        str(getattr(spec, "continuity_mode", "native")),
+    )
+    return f"{note}\n\n{prompt}" if note else prompt

--- a/proteus/core/episode.py
+++ b/proteus/core/episode.py
@@ -25,11 +25,9 @@ from typing import Mapping
 
 from proteus.core import snapshot
 from proteus.core.adapter import EpisodeSpec, HarnessAdapter
+from proteus.core.budget import PHASES, make_budget_plan
 from proteus.core.disposition import Disposition
 from proteus.core.goal import GoalConfig, GoalContext
-
-PHASES = ("observe", "propose", "act", "reflect")
-
 
 def _write_json_atomic(path: Path, value) -> None:
     """Replace one JSON record without exposing a truncated crash-time file."""
@@ -160,6 +158,12 @@ class RunConfig:
     min_turns_per_phase: int = 0
     """Per-phase floor on the turn budget (see EpisodeSpec). `max_turns` must be at
     least `len(PHASES) * min_turns_per_phase`."""
+    phase_turns: Mapping[str, int] = field(default_factory=dict)
+    """Explicit normal allocation for all four phases; must sum to ``max_turns``."""
+    hard_max_turns: int = 0
+    """Burst ceiling for an explicit phase plan. Zero uses ``max_turns``."""
+    checkpoint_turns: int = 0
+    """End-of-phase calls reserved for the harness's persistent handoff mechanism."""
     seed: int = 0
     task: object | None = None
     """A `proteus.bench.BenchTask` to seed before episode 1. Its workspace is
@@ -170,12 +174,11 @@ class RunConfig:
     """Optional isolated runner for agent-authored benchmark code. Local/polyglot use a
     networkless Docker grader by default; host execution is never a fallback."""
     announce_budget: bool = False
-    """Tell the agent its per-episode budget (`max_turns`) in every phase prompt, so it
-    can plan within it. Off by default: announcing the budget changes behaviour — that is
-    the point — so it is an experimental condition, recorded in the manifest, not a
-    silent default. Enforcement is separate and always on where possible: hard cap for
-    in-process harnesses, between-phase budget checks and mid-phase log watching for
-    containerized ones."""
+    """Tell the agent its live phase allocation and episode limits, so it can plan within
+    them. Off by default: announcing a budget changes behaviour — that is the point — so
+    it is an experimental condition, recorded in the manifest, not a silent default.
+    Enforcement is separate and always on where possible: direct stops for in-process
+    harnesses, between-phase checks and mid-phase log watching for containerized ones."""
     progress_path: Path | None = None
     """Where to append one JSON line per finished episode (live tracking). Must live
     OUTSIDE `root`: the subject agent can read its own run root, and a progress record
@@ -232,11 +235,18 @@ def _phase_prompts(cfg: RunConfig, prior_feedback: str) -> dict[str, str]:
         prompts["observe"] = f"{prior_feedback}\n\n{prompts['observe']}"
     # the budget announcement comes first: it frames how the agent plans the episode
     if cfg.announce_budget and cfg.max_turns:
-        note = (f"Budget: you have at most {cfg.max_turns} tool calls in this episode, "
-                "across all phases. Plan within it; the episode ends when it is spent.")
-        if cfg.min_turns_per_phase:
+        hard = cfg.hard_max_turns or cfg.max_turns
+        note = (f"Budget condition: you have at most {hard} tool calls in this episode; "
+                f"the normal plan is {cfg.max_turns} across all phases. The adapter will "
+                "report live used and remaining counts at phase start.")
+        if cfg.phase_turns:
+            allocation = ", ".join(
+                f"{phase}={cfg.phase_turns[phase]}" for phase in PHASES
+            )
+            note += f" Planned phase allocation: {allocation}; unused quota goes to act."
+        elif cfg.min_turns_per_phase:
             note += (f" Each later phase reserves at least {cfg.min_turns_per_phase} "
-                     "of them; a phase may be ended early to protect that reserve.")
+                     "calls; a phase may be ended early to protect that reserve.")
         for ph in PHASES:
             prompts[ph] = f"{note}\n\n{prompts[ph]}"
     # the disposition contributes its (per-phase) text — unless the adapter already carries
@@ -301,11 +311,19 @@ def run(cfg: RunConfig, start: int = 0, *, resume: bool = False) -> RunResult:
     harness = cfg.root / "harness"
     records = private_record_dir(cfg.root)
     staged_activation = bool(getattr(cfg.adapter, "staged_activation", False))
-    if cfg.max_turns and cfg.min_turns_per_phase * len(PHASES) > cfg.max_turns:
+    make_budget_plan(
+        max_turns=cfg.max_turns,
+        min_turns_per_phase=cfg.min_turns_per_phase,
+        phase_turns=cfg.phase_turns,
+        hard_max_turns=cfg.hard_max_turns,
+        checkpoint_turns=cfg.checkpoint_turns,
+    )
+    if cfg.checkpoint_turns and not cfg.announce_budget:
+        raise ValueError("checkpoint_turns requires announce_budget")
+    if cfg.checkpoint_turns and getattr(cfg.adapter, "continuity_mode", "native") == "none":
         raise ValueError(
-            f"max_turns={cfg.max_turns} cannot honour min_turns_per_phase="
-            f"{cfg.min_turns_per_phase}: {len(PHASES)} phases need at least "
-            f"{cfg.min_turns_per_phase * len(PHASES)} turns")
+            "checkpoint_turns requires a harness with native or framework continuity"
+        )
     completed = completed_episodes(cfg)
     is_resume = resume or bool(start)
     if is_resume:
@@ -467,6 +485,9 @@ def run(cfg: RunConfig, start: int = 0, *, resume: bool = False) -> RunResult:
             phase_prompts=_phase_prompts(cfg, prior_feedback),
             max_turns=cfg.max_turns, seed=cfg.seed,
             min_turns_per_phase=cfg.min_turns_per_phase,
+            phase_turns=dict(cfg.phase_turns), hard_max_turns=cfg.hard_max_turns,
+            checkpoint_turns=cfg.checkpoint_turns,
+            announce_budget=cfg.announce_budget,
             continuity_mode=getattr(cfg.adapter, "continuity_mode", "native"),
             active_root=active_root,
         )

--- a/proteus/sweep.py
+++ b/proteus/sweep.py
@@ -15,6 +15,7 @@ from pathlib import Path
 from typing import Any, Callable, Mapping, Sequence
 
 from proteus.core.adapter import HarnessAdapter
+from proteus.core.budget import BUDGET_PROTOCOL_VERSION, PHASES, make_budget_plan
 from proteus.core.continuity import PROTOCOL_VERSION
 from proteus.core.disposition import Disposition
 from proteus.core.episode import RunConfig, completed_episodes, run
@@ -135,7 +136,7 @@ def _condition(cfg: "SweepConfig", adapter: HarnessAdapter) -> dict:
             "id": str(getattr(cfg.task, "id", type(cfg.task).__name__)),
             "base_commit": str(getattr(cfg.task, "base_commit", "")),
         }
-    return {
+    condition = {
         "proteus_version": __version__,
         "continuity_protocol_version": (
             PROTOCOL_VERSION
@@ -158,6 +159,23 @@ def _condition(cfg: "SweepConfig", adapter: HarnessAdapter) -> dict:
         "grader_sandbox": _sandbox_condition(cfg.grader_sandbox),
         "metadata": _json_value(cfg.condition_metadata),
     }
+    if cfg.phase_turns or cfg.hard_max_turns or cfg.checkpoint_turns:
+        plan = make_budget_plan(
+            max_turns=cfg.max_turns,
+            min_turns_per_phase=cfg.min_turns_per_phase,
+            phase_turns=cfg.phase_turns,
+            hard_max_turns=cfg.hard_max_turns,
+            checkpoint_turns=cfg.checkpoint_turns,
+        )
+        condition["budget_protocol"] = {
+            "version": BUDGET_PROTOCOL_VERSION,
+            "normal_limit": plan.normal_limit,
+            "hard_limit": plan.hard_limit,
+            "phase_turns": {phase: plan.phase_allowances[phase] for phase in PHASES},
+            "checkpoint_turns": plan.checkpoint_turns,
+            "unused_priority": "act",
+        }
+    return condition
 
 
 def _write_json_atomic(path: Path, value: Any) -> None:
@@ -193,6 +211,9 @@ class SweepConfig:
     grader_sandbox: object | None = None
     """Optional isolated grader runner propagated to every benchmark evaluator."""
     min_turns_per_phase: int = 0
+    phase_turns: Mapping[str, int] = field(default_factory=dict)
+    hard_max_turns: int = 0
+    checkpoint_turns: int = 0
     announce_budget: bool = False
     on_existing: str = "refuse"
     """What to do when a run root is already there: "refuse" (default), "resume", or
@@ -263,6 +284,21 @@ def completed_episodes_in(run_root: Path) -> int:
 def run_sweep(cfg: SweepConfig) -> list[dict]:
     if cfg.on_existing not in ("refuse", "resume", "overwrite"):
         raise ValueError(f"on_existing must be refuse/resume/overwrite, got {cfg.on_existing!r}")
+    plan = make_budget_plan(
+        max_turns=cfg.max_turns,
+        min_turns_per_phase=cfg.min_turns_per_phase,
+        phase_turns=cfg.phase_turns,
+        hard_max_turns=cfg.hard_max_turns,
+        checkpoint_turns=cfg.checkpoint_turns,
+    )
+    if cfg.checkpoint_turns and not cfg.announce_budget:
+        raise ValueError("checkpoint_turns requires announce_budget")
+    manifest_adapter = cfg.adapter_factory()
+    continuity_mode = getattr(manifest_adapter, "continuity_mode", "native")
+    if cfg.checkpoint_turns and continuity_mode == "none":
+        raise ValueError(
+            "checkpoint_turns requires a harness with native or framework continuity"
+        )
     cfg.root.mkdir(parents=True, exist_ok=True)
     runs = [{"id": opaque_id(arm.label, s), "arm": arm.label, "seed": s}
             for arm in cfg.arms for s in range(cfg.seeds)]
@@ -275,8 +311,6 @@ def run_sweep(cfg: SweepConfig) -> list[dict]:
 
     # Constructing the declaration adapter is side-effect free. Its public runtime knobs
     # form part of the condition; credentials are deliberately never inspected.
-    manifest_adapter = cfg.adapter_factory()
-    continuity_mode = getattr(manifest_adapter, "continuity_mode", "native")
     condition = _condition(cfg, manifest_adapter)
 
     # Validate before mutating anything. Previously even a refused second invocation
@@ -335,6 +369,15 @@ def run_sweep(cfg: SweepConfig) -> list[dict]:
         },
         "condition": condition,
     }
+    if plan.explicit:
+        manifest["budget"] = {
+            "protocol_version": BUDGET_PROTOCOL_VERSION,
+            "normal_limit": plan.normal_limit,
+            "hard_limit": plan.hard_limit,
+            "phase_turns": {phase: plan.phase_allowances[phase] for phase in PHASES},
+            "checkpoint_turns": plan.checkpoint_turns,
+            "unused_priority": "act",
+        }
     # Preserve an already-validated resume manifest exactly. A refused or failed resume
     # must be observationally read-only; a new/overwrite sweep publishes atomically.
     if existing_manifest is None:
@@ -361,6 +404,8 @@ def run_sweep(cfg: SweepConfig) -> list[dict]:
                 goal=cfg.goal, root=run_root, model=cfg.model,
                 episodes=cfg.episodes, max_turns=cfg.max_turns, seed=s,
                 min_turns_per_phase=cfg.min_turns_per_phase,
+                phase_turns=dict(cfg.phase_turns), hard_max_turns=cfg.hard_max_turns,
+                checkpoint_turns=cfg.checkpoint_turns,
                 announce_budget=cfg.announce_budget, task=cfg.task,
                 grader_sandbox=cfg.grader_sandbox,
                 progress_path=cfg.root / "progress" / f"{rid}.jsonl",

--- a/tests/test_goals.py
+++ b/tests/test_goals.py
@@ -289,3 +289,35 @@ def test_cli_rejects_invalid_turn_reservations_without_traceback(tmp_path):
         assert "use --max-turns >= 8" in str(exc)
     else:
         raise AssertionError("invalid reservation was accepted")
+
+
+def test_cli_accepts_and_records_an_explicit_phase_budget(tmp_path):
+    import json
+    from proteus import cli
+
+    root = tmp_path / "phase-budget"
+    rc = cli.main([
+        "run", "--harness", "minimal", "--arm", "neutral", "--seeds", "1",
+        "--episodes", "1", "--max-turns", "8", "--hard-max-turns", "12",
+        "--phase-turns", "observe=2,propose=2,act=2,reflect=2",
+        "--announce-budget", "--out", str(root),
+    ])
+    assert rc == 0
+    manifest = json.loads((root / "manifest.json").read_text())
+    assert manifest["budget"]["hard_limit"] == 12
+
+
+def test_checkpoint_budget_requires_announcement(tmp_path):
+    from proteus import cli
+
+    try:
+        cli.main([
+            "run", "--harness", "dsh", "--arm", "neutral", "--seeds", "1",
+            "--episodes", "1", "--max-turns", "8",
+            "--phase-turns", "observe=2,propose=2,act=2,reflect=2",
+            "--checkpoint-turns", "1", "--out", str(tmp_path / "bad-checkpoint"),
+        ])
+    except SystemExit as exc:
+        assert "requires --announce-budget" in str(exc)
+    else:
+        raise AssertionError("a hidden checkpoint reserve was accepted")

--- a/tests/test_instrument.py
+++ b/tests/test_instrument.py
@@ -527,6 +527,30 @@ def test_sweep_manifest_records_the_model(tmp_path):
     manifest = json.loads((root / "manifest.json").read_text())
     assert manifest["model"] == "mock"
     assert manifest["condition"]["proteus_version"] == __version__
+    assert "budget" not in manifest
+    assert "budget_protocol" not in manifest["condition"]
+
+
+def test_sweep_manifest_records_the_full_budget_protocol(tmp_path):
+    import json
+    from proteus.sweep import run_sweep
+
+    cfg = _sweep_cfg(
+        tmp_path / "budgeted", max_turns=12, hard_max_turns=20,
+        phase_turns={"observe": 2, "propose": 2, "act": 6, "reflect": 2},
+        announce_budget=True,
+    )
+    run_sweep(cfg)
+    manifest = json.loads((cfg.root / "manifest.json").read_text())
+    assert manifest["budget"] == {
+        "protocol_version": 1,
+        "normal_limit": 12,
+        "hard_limit": 20,
+        "phase_turns": {"observe": 2, "propose": 2, "act": 6, "reflect": 2},
+        "checkpoint_turns": 0,
+        "unused_priority": "act",
+    }
+    assert manifest["condition"]["budget_protocol"]["hard_limit"] == 20
 
 
 def test_resume_skips_completed_seeds(tmp_path):

--- a/tests/test_selfcode.py
+++ b/tests/test_selfcode.py
@@ -284,6 +284,24 @@ def test_source_hash_frames_file_boundaries_and_symlinks(tmp_path):
 
 # ------------------------------------------------------------------- turn budget
 
+def test_explicit_budget_validation_is_strict():
+    from proteus.core.budget import make_budget_plan
+
+    base = {"observe": 2, "propose": 2, "act": 6, "reflect": 2}
+    invalid = [
+        ({"phase_turns": {**base, "act": 5}}, "sum to 11"),
+        ({"phase_turns": base, "hard_max_turns": 11}, "must be at least"),
+        ({"phase_turns": base, "min_turns_per_phase": 1}, "cannot be combined"),
+        ({"phase_turns": base, "checkpoint_turns": 3}, "smallest"),
+    ]
+    for overrides, expected in invalid:
+        try:
+            make_budget_plan(max_turns=12, **overrides)
+        except ValueError as exc:
+            assert expected in str(exc)
+        else:
+            raise AssertionError(f"invalid budget was accepted: {overrides}")
+
 def test_budget_stops_new_phases_exactly(tmp_path):
     # the between-phase check is exact and needs nothing from the log format
     from proteus.core.adapter import EpisodeSpec
@@ -450,3 +468,114 @@ def test_budget_must_cover_the_reserves(tmp_path):
         assert "min_turns_per_phase" in str(exc)
     else:
         raise AssertionError("a budget below 4x the reserve must be refused")
+
+
+def test_explicit_phase_budget_gives_unused_and_burst_capacity_to_act(tmp_path):
+    from proteus.adapters.minimal import MinimalHarness
+    from proteus.core import NEUTRAL, GoalConfig
+    from proteus.core.episode import RunConfig, run
+
+    def policy(phase, prompt, episode, rng):
+        count = 1 if phase in ("observe", "propose") else 50
+        return [("read_state", None, f"{phase}-{i}") for i in range(count)]
+
+    adapter = MinimalHarness(policy=policy)
+    result = run(RunConfig(
+        name="budget", adapter=adapter, disposition=NEUTRAL, goal=GoalConfig(),
+        root=tmp_path / "explicit", model="mock", episodes=1,
+        max_turns=12, hard_max_turns=20,
+        phase_turns={"observe": 2, "propose": 2, "act": 6, "reflect": 2},
+    ))
+    trace = adapter.read_trace(tmp_path / "explicit", 1)
+    counts = {phase: sum(event.phase == phase for event in trace)
+              for phase in ("observe", "propose", "act", "reflect")}
+    assert counts == {"observe": 1, "propose": 1, "act": 16, "reflect": 2}
+    assert result.eval_history[0]["counters"]["phase_act_turns"] == 16
+
+
+def test_explicit_phase_budget_does_not_let_reflect_borrow_act_capacity(tmp_path):
+    from proteus.adapters.minimal import MinimalHarness
+    from proteus.core.adapter import EpisodeSpec
+
+    def policy(phase, prompt, episode, rng):
+        count = 50 if phase == "reflect" else 1
+        return [("read_state", None, f"{phase}-{i}") for i in range(count)]
+
+    adapter = MinimalHarness(policy=policy)
+    root = tmp_path / "reflect-cap"
+    adapter.seed(root / "harness")
+    result = adapter.run_episode(EpisodeSpec(
+        root=root, episode=1, model="mock", phase_prompts={},
+        max_turns=12, hard_max_turns=20,
+        phase_turns={"observe": 2, "propose": 2, "act": 6, "reflect": 2},
+    ))
+    assert result.counters["phase_reflect_turns"] == 2
+    assert result.turns == 5
+
+
+def test_live_budget_prompt_reports_phase_start_state(tmp_path):
+    from proteus.adapters.minimal import MinimalHarness
+    from proteus.core.adapter import EpisodeSpec
+
+    seen = {}
+
+    def policy(phase, prompt, episode, rng):
+        seen[phase] = prompt
+        return [("read_state", None, phase)]
+
+    adapter = MinimalHarness(policy=policy)
+    root = tmp_path / "live-prompt"
+    adapter.seed(root / "harness")
+    result = adapter.run_episode(EpisodeSpec(
+        root=root, episode=7, model="mock", phase_prompts={}, announce_budget=True,
+        max_turns=8, hard_max_turns=12,
+        phase_turns={"observe": 2, "propose": 2, "act": 2, "reflect": 2},
+    ))
+    assert result.ok
+    assert "episode 7, phase observe" in seen["observe"]
+    assert "calls already used before this phase: 0" in seen["observe"]
+    assert "calls already used before this phase: 2" in seen["act"]
+    assert "episode hard ceiling: 12" in seen["act"]
+    assert "act owns unused earlier-phase allowance and up to 4 burst calls" in seen["act"]
+
+
+def test_checkpoint_reserve_is_agent_authored_and_visible():
+    from proteus.core.adapter import EpisodeSpec
+    from proteus.core.budget import phase_prompt
+
+    spec = EpisodeSpec(
+        root=Path("."), episode=3, model="m", phase_prompts={"act": "do work"},
+        max_turns=12, hard_max_turns=20, checkpoint_turns=2,
+        phase_turns={"observe": 2, "propose": 2, "act": 6, "reflect": 2},
+        announce_budget=True, continuity_mode="framework",
+    )
+    prompt = phase_prompt(spec, "act", 4)
+    assert "checkpoint reserve: keep final 2 calls" in prompt
+    assert "cumulative call 16" in prompt
+    assert "/workspace/.proteus/handoff.md" in prompt
+    assert "will not invent a semantic summary" in prompt
+
+
+def test_explicit_phase_budget_stops_container_phases_at_the_same_lines(tmp_path):
+    from proteus.core.adapter import EpisodeSpec
+
+    for i, cls in enumerate((DshHarness, PiHarness)):
+        sandbox = FakeSandbox()
+        adapter = cls(key="x", sandbox=sandbox)
+        script = iter([0, 2, 2, 2, 4, 4, 4, 18, 18, 18, 20, 20])
+        adapter._live_calls = lambda *args, **kw: next(script, 20)
+        harness = tmp_path / f"explicit-container-harness-{i}"
+        _seed_with_fake_src(adapter, harness, ())
+        root = tmp_path / f"explicit-container-root-{i}"
+        root.mkdir()
+        (root / "harness").symlink_to(harness)
+        result = adapter.run_episode(EpisodeSpec(
+            root=root, episode=1, model="m", phase_prompts={},
+            max_turns=12, hard_max_turns=20, checkpoint_turns=1,
+            phase_turns={"observe": 2, "propose": 2, "act": 6, "reflect": 2},
+            announce_budget=True, continuity_mode="framework",
+        ))
+        phases = [call for call in sandbox.calls if call["command"] != ["--version"]]
+        assert len(phases) == 4, cls.__name__
+        assert result.ok and result.counters["turn_capped"], cls.__name__
+        assert result.counters["checkpoint_misses"] == 4, cls.__name__


### PR DESCRIPTION
## Summary

- add a harness-neutral `BudgetPlan` shared by bundled and custom adapters
- support explicit observe/propose/act/reflect allocations, a separate burst ceiling, and live phase-start budget prompts
- prioritise unused early-phase quota and burst capacity for Act while keeping Reflect bounded by its own allocation
- reserve an agent-visible checkpoint tail, archive agent-authored handoffs, and report `checkpoint_misses` without synthesising semantic memory
- record the complete versioned budget condition in `manifest.json` and lock it across resume
- document the adapter contract and a recommended 300 normal / 500 hard source-evolution setup

## Compatibility

Existing `max_turns` and `min_turns_per_phase` configurations preserve their prior behaviour. The new protocol is opt-in, so currently running 100-call trajectories are unchanged.

## Verification

- `127 passed, 1 skipped`
- offline runner: `111 passed, 0 failed`
- `ruff check .`
- `git diff --check`