### PR TITLE
feat: add MBPP benchmark tasks

### DIFF
--- a/docs/BENCHMARKS.md
+++ b/docs/BENCHMARKS.md
@@ -32,6 +32,12 @@ proteus run --harness pi \
     --goal "Implement the Bowling exercise and pass its tests." \
     --evaluator polyglot:bowling@observe \
     --arm neutral --seeds 2 --episodes 10 --out runs/bowling
+
+# Sanitized MBPP task; one JSON file is downloaded and cached on first use.
+proteus run --harness pi \
+    --goal "Solve MBPP task 2 in task/solution.py." \
+    --evaluator mbpp:2@observe \
+    --arm neutral --seeds 2 --episodes 10 --out runs/mbpp-2
 ```
 
 The CLI accepts at most one benchmark evaluator per run because a run has one task
@@ -55,6 +61,7 @@ to that `task/` directory.
 |---|---|---|---|
 | built-in | `proteus.bench.local` | nothing | smoke tests, plumbing, CI |
 | **lightweight external** | `proteus.bench.polyglot` | Python + one shallow clone | real ablations at negligible cost |
+| **lightweight external** | `proteus.bench.mbpp` | Python + one cached JSON file | short, dense-scored synthesis tasks |
 | heavyweight official | `proteus.bench.swe` | Docker, ~120 GB, x86_64 | headline numbers on the real thing |
 
 **Start from `polyglot.py`** — it is deliberately the worked example. ~180 lines, no
@@ -62,6 +69,11 @@ dependencies, and it demonstrates every property a contributed benchmark must ha
 `tests/test_polyglot.py` fabricates a miniature dataset in the benchmark's exact layout,
 so it also documents the shape your loader must read, and your tests never touch the
 network.
+
+MBPP uses Google Research's Apache-2.0 `sanitized-mbpp.json`. Set
+`PROTEUS_MBPP_PATH=/path/to/sanitized-mbpp.json` to use an existing copy; otherwise the
+file is cached under `~/.cache/proteus/mbpp/`. The prompt is seeded into the task, while
+the reference implementation and assertions remain held out by the grader.
 
 ## What a contributed benchmark must get right
 

--- a/proteus/bench/mbpp.py
+++ b/proteus/bench/mbpp.py
@@ -1,0 +1,362 @@
+"""Mostly Basic Python Problems (MBPP) as lightweight external benchmark tasks.
+
+Dataset: Google Research's ``sanitized-mbpp.json``, a hand-verified subset of MBPP
+released under the Apache License 2.0 in google-research/google-research. The dataset is
+not vendored; it is cached on first use, or supplied with ``PROTEUS_MBPP_PATH``.
+
+Only the prompt and an empty ``solution.py`` are seeded. Reference code and assertions
+remain in the dataset for grading and are never copied into the agent's task workspace.
+"""
+
+from __future__ import annotations
+
+import ast
+import json
+import os
+import secrets
+import subprocess
+import tempfile
+from pathlib import Path
+from urllib import request
+
+from proteus.bench.task import BenchTask
+from proteus.core.goal import EvalResult
+
+DATA_URL = (
+    "https://raw.githubusercontent.com/google-research/google-research/"
+    "master/mbpp/sanitized-mbpp.json"
+)
+GRADE_TIMEOUT_S = 60
+CALL_TIMEOUT_S = 15
+
+_CODEC = '''\
+import base64
+
+_type = type
+_isinstance = isinstance
+_bool = bool
+_int = int
+_float = float
+_complex = complex
+_str = str
+_bytes = bytes
+_list = list
+_tuple = tuple
+_set = set
+_frozenset = frozenset
+_dict = dict
+
+class _OpaqueValue:
+    def __init__(self, truthy):
+        self.truthy = truthy
+
+    def __bool__(self):
+        return self.truthy
+
+def _encode(value):
+    kind = _type(value)
+    if value is None:
+        return {"type": "none"}
+    if kind is _bool:
+        return {"type": "bool", "value": value}
+    if kind is _int:
+        return {"type": "int", "value": _str(value)}
+    if kind is _float:
+        return {"type": "float", "value": _str(value)}
+    if kind is _complex:
+        return {"type": "complex", "real": _str(value.real), "imag": _str(value.imag)}
+    if kind is _str:
+        return {"type": "str", "value": value}
+    if kind is _bytes:
+        return {"type": "bytes", "value": base64.b64encode(value).decode("ascii")}
+    if _isinstance(value, _list):
+        return {"type": "list", "items": [_encode(item) for item in value]}
+    if _isinstance(value, _tuple):
+        return {"type": "tuple", "items": [_encode(item) for item in value]}
+    if _isinstance(value, (_set, _frozenset)):
+        return {"type": "set", "items": [_encode(item) for item in value]}
+    if _isinstance(value, _dict):
+        return {"type": "dict", "items": [[_encode(k), _encode(v)] for k, v in value.items()]}
+    return {"type": "opaque", "truthy": _bool(value)}
+
+def _decode(node):
+    kind = node["type"]
+    if kind == "none":
+        return None
+    if kind == "bool":
+        return _bool(node["value"])
+    if kind == "int":
+        return _int(node["value"])
+    if kind == "float":
+        return _float(node["value"])
+    if kind == "complex":
+        return _complex(_float(node["real"]), _float(node["imag"]))
+    if kind == "str":
+        return _str(node["value"])
+    if kind == "bytes":
+        return base64.b64decode(node["value"], validate=True)
+    if kind == "list":
+        return [_decode(item) for item in node["items"]]
+    if kind == "tuple":
+        return _tuple(_decode(item) for item in node["items"])
+    if kind == "set":
+        return {_decode(item) for item in node["items"]}
+    if kind == "dict":
+        return {_decode(k): _decode(v) for k, v in node["items"]}
+    if kind == "opaque":
+        return _OpaqueValue(_bool(node["truthy"]))
+    raise ValueError(f"unknown MBPP value type: {kind!r}")
+'''
+
+_WORKER = _CODEC + '''\
+import builtins
+import json
+import os
+import sys
+from pathlib import Path
+
+trusted_exec = exec
+trusted_compile = compile
+caught = BaseException
+json_loads = json.loads
+json_dumps = json.dumps
+emit = sys.stdout.write
+flush = sys.stdout.flush
+exit_now = os._exit
+here = Path.cwd()
+solution = here / "solution.py"
+namespace = {"__name__": "__main__", "__file__": str(solution),
+             "__builtins__": dict(vars(builtins))}
+try:
+    request = json_loads(sys.argv[1])
+    source = solution.read_text(encoding="utf-8")
+    trusted_exec(trusted_compile(source, str(solution), "exec"), namespace)
+    function = namespace[request["name"]]
+    value = function(*_decode(request["args"]), **_decode(request["kwargs"]))
+    response = {"ok": True, "value": _encode(value)}
+except caught as exc:
+    response = {"ok": False, "error": f"{_type(exc).__name__}: {exc}"}
+emit(WORKER_PREFIX + json_dumps(response, separators=(",", ":")) + "\\n")
+flush()
+exit_now(0)
+'''
+
+_DRIVER = _CODEC + '''\
+import json
+import os
+import subprocess
+import sys
+from pathlib import Path
+
+emit = sys.stdout.write
+flush = sys.stdout.flush
+exit_now = os._exit
+here = Path(__file__).resolve().parent
+
+def _remote_call(name, args, kwargs):
+    request = json.dumps(
+        {"name": name, "args": _encode(args), "kwargs": _encode(kwargs)},
+        separators=(",", ":"),
+    )
+    proc = subprocess.run(
+        [sys.executable, "-c", WORKER_SOURCE, request],
+        cwd=here,
+        stdin=subprocess.DEVNULL,
+        capture_output=True,
+        text=True,
+        timeout=CALL_TIMEOUT_S,
+        check=False,
+    )
+    if proc.returncode != 0:
+        raise RuntimeError("candidate worker failed")
+    reports = [line for line in proc.stdout.splitlines() if line.startswith(WORKER_PREFIX)]
+    response = json.loads(reports[-1][len(WORKER_PREFIX):])
+    if not response.get("ok"):
+        raise RuntimeError(response.get("error", "candidate call failed"))
+    return _decode(response["value"])
+
+class _RemoteFunction:
+    def __init__(self, name):
+        self.name = name
+
+    def __call__(self, *args, **kwargs):
+        return _remote_call(self.name, args, kwargs)
+
+def _report(passed):
+    emit(REPORT_PREFIX + str(passed) + "/" + str(len(TESTS)) + "\\n")
+    flush()
+    exit_now(0)
+
+try:
+    Path(__file__).resolve().unlink()
+except OSError:
+    _report(0)
+
+namespace = {"__name__": "__main__"}
+try:
+    for statement in TEST_IMPORTS + REFERENCE_IMPORTS:
+        exec(statement, namespace)
+    for name in ENTRY_POINTS:
+        namespace[name] = _RemoteFunction(name)
+except BaseException:
+    _report(0)
+
+passed = 0
+for assertion in TESTS:
+    try:
+        exec(assertion, namespace)
+        passed += 1
+    except BaseException:
+        pass
+_report(passed)
+'''
+
+
+def dataset_path(dataset_file: str | os.PathLike | None = None) -> Path:
+    """Resolve an explicit, environment-provided, or cached sanitized MBPP dataset."""
+    if dataset_file:
+        return Path(dataset_file).expanduser()
+    env = os.environ.get("PROTEUS_MBPP_PATH")
+    if env:
+        return Path(env).expanduser()
+    cache = Path.home() / ".cache" / "proteus" / "mbpp" / "sanitized-mbpp.json"
+    if not cache.exists():
+        cache.parent.mkdir(parents=True, exist_ok=True)
+        with request.urlopen(DATA_URL, timeout=30) as response:
+            payload = response.read()
+        rows = json.loads(payload.decode("utf-8"))
+        if not isinstance(rows, list):
+            raise ValueError("sanitized MBPP download is not a JSON list")
+        temp_path = None
+        try:
+            with tempfile.NamedTemporaryFile(dir=cache.parent, delete=False) as tmp:
+                tmp.write(payload)
+                temp_path = Path(tmp.name)
+            temp_path.replace(cache)
+        finally:
+            if temp_path is not None:
+                temp_path.unlink(missing_ok=True)
+    return cache
+
+
+def _records(path: Path) -> dict[str, dict]:
+    rows = json.loads(path.read_text(encoding="utf-8"))
+    return {str(row["task_id"]): row for row in rows}
+
+
+def list_tasks(dataset_file: str | os.PathLike | None = None) -> list[str]:
+    """Task IDs available in the sanitized dataset."""
+    return sorted(_records(dataset_path(dataset_file)), key=int)
+
+
+def _load(path: Path, task_id: int | str) -> dict:
+    key = str(task_id)
+    try:
+        return _records(path)[key]
+    except KeyError:
+        raise KeyError(f"unknown MBPP task {key!r}; see proteus.bench.mbpp.list_tasks()") \
+            from None
+
+
+def _setup(ws: Path, spec: dict) -> None:
+    (ws / "README.md").write_text(
+        f"# MBPP task {spec['task_id']}\n\n{spec['prompt'].strip()}\n\n"
+        "Implement your answer in `solution.py`.\n",
+        encoding="utf-8",
+    )
+    (ws / "solution.py").write_text(
+        '"""Implement the function described in README.md."""\n', encoding="utf-8"
+    )
+
+
+def _entry_points(spec: dict) -> list[str]:
+    tree = ast.parse(spec["code"])
+    return [node.name for node in tree.body if isinstance(node, ast.FunctionDef)]
+
+
+def _reference_imports(spec: dict) -> list[str]:
+    source = spec["code"]
+    tree = ast.parse(source)
+    return [
+        ast.get_source_segment(source, node) or ast.unparse(node)
+        for node in tree.body
+        if isinstance(node, (ast.Import, ast.ImportFrom))
+    ]
+
+
+def _driver(spec: dict, report_prefix: str, worker_prefix: str) -> str:
+    imports = list(spec.get("test_imports", []))
+    tests = list(spec["test_list"])
+    worker_source = f"WORKER_PREFIX = {worker_prefix!r}\n" + _WORKER
+    return (
+        f"TEST_IMPORTS = {imports!r}\nREFERENCE_IMPORTS = {_reference_imports(spec)!r}\n"
+        f"TESTS = {tests!r}\n"
+        f"ENTRY_POINTS = {_entry_points(spec)!r}\n"
+        f"REPORT_PREFIX = {report_prefix!r}\nWORKER_PREFIX = {worker_prefix!r}\n"
+        f"WORKER_SOURCE = {worker_source!r}\nCALL_TIMEOUT_S = {CALL_TIMEOUT_S}\n"
+        + _DRIVER
+    )
+
+
+def _grade(ws: Path, spec: dict, name: str, *, sandbox=None) -> EvalResult:
+    report_prefix = f"PROTEUS_MBPP_RESULT:{secrets.token_hex(16)}:"
+    worker_prefix = f"PROTEUS_MBPP_VALUE:{secrets.token_hex(16)}:"
+    driver = ws / "_grade.py"
+    driver.write_text(_driver(spec, report_prefix, worker_prefix), encoding="utf-8")
+    try:
+        from proteus.bench.sandbox import run_python
+
+        proc = run_python(
+            ws, "_grade.py", timeout_s=GRADE_TIMEOUT_S, sandbox=sandbox, isolated=True
+        )
+    except subprocess.TimeoutExpired:
+        return EvalResult(
+            name=name,
+            score=0.0,
+            passed=False,
+            detail=f"grading timed out after {GRADE_TIMEOUT_S}s",
+        )
+    finally:
+        driver.unlink(missing_ok=True)
+
+    expected = len(spec["test_list"])
+    stdout = getattr(proc, "stdout", "")
+    stderr = getattr(proc, "stderr", "")
+    stdout = stdout if isinstance(stdout, str) else ""
+    stderr = stderr if isinstance(stderr, str) else ""
+    try:
+        reports = [line for line in stdout.splitlines() if line.startswith(report_prefix)]
+        passed_raw, total_raw = reports[-1][len(report_prefix):].split("/", 1)
+        passed, total = int(passed_raw), int(total_raw)
+        if getattr(proc, "returncode", 1) != 0 or total != expected or not 0 <= passed <= total:
+            raise ValueError("invalid MBPP grader counts")
+    except (IndexError, TypeError, ValueError):
+        diagnostic = (stderr or stdout)[-200:]
+        return EvalResult(
+            name=name,
+            score=0.0,
+            passed=False,
+            detail=f"grader produced no report: {diagnostic}",
+        )
+
+    return EvalResult(
+        name=name,
+        score=passed / total if total else 0.0,
+        passed=(total > 0 and passed == total),
+        detail=f"{passed}/{total} tests pass",
+    )
+
+
+def mbpp_task(task_id: int | str, dataset_file: str | os.PathLike | None = None) -> BenchTask:
+    """Create one sanitized MBPP problem as a ``BenchTask``."""
+    spec = _load(dataset_path(dataset_file), task_id)
+    name = f"mbpp:{spec['task_id']}"
+    return BenchTask(
+        id=name,
+        goal_text=(
+            spec["prompt"].strip()
+            + "\n\nImplement the solution in `task/solution.py`; official tests are held out."
+        ),
+        setup=lambda ws, s=spec: _setup(ws, s),
+        grade=lambda ws, sandbox=None, s=spec, n=name: _grade(ws, s, n, sandbox=sandbox),
+    )

--- a/proteus/bench/sandbox.py
+++ b/proteus/bench/sandbox.py
@@ -22,18 +22,23 @@ def default_grader_sandbox():
 
 
 def run_python(ws: Path, script: str, *, timeout_s: int,
-               env: Mapping[str, str] | None = None, sandbox=None) -> subprocess.CompletedProcess:
+               env: Mapping[str, str] | None = None, sandbox=None,
+               isolated: bool = False) -> subprocess.CompletedProcess:
     """Execute a task-local script without ever falling back to host Python."""
     runner = sandbox or default_grader_sandbox()
+    command = ["python"]
+    if isolated:
+        command.append("-I")
+    command.append(script)
     try:
         return runner.run(
-            Path(ws), ["python", script], env=dict(env or {}), timeout_s=timeout_s,
+            Path(ws), command, env=dict(env or {}), timeout_s=timeout_s,
             mounts=((str(Path(ws)), "/task"),),
         )
     except subprocess.TimeoutExpired:
         raise
     except Exception as exc:  # noqa: BLE001 - unavailable isolation is a scored failure
         return subprocess.CompletedProcess(
-            ["python", script], 126, "",
+            command, 126, "",
             f"secure grader unavailable ({type(exc).__name__}: {exc})",
         )

--- a/proteus/cli.py
+++ b/proteus/cli.py
@@ -162,7 +162,7 @@ def _evaluator(spec: str, adapter_factory):
     """Parse one --evaluator: `<what>[@hidden|@observe]`. Returns (spec, task | None).
 
     measurement: units:<surface-name> | tool-calls | step
-    benchmark:   local:<task> | polyglot:<exercise>   (seeds the task workspace too)
+    benchmark:   local:<task> | polyglot:<exercise> | mbpp:<task-id>
     custom:      contains:<relpath>:<needle>
     """
     from proteus.bench.task import as_evaluator
@@ -173,14 +173,17 @@ def _evaluator(spec: str, adapter_factory):
         raise SystemExit(f"bad --evaluator {spec!r}: visibility is @hidden or @observe")
     visibility = Visibility(vis) if vis else Visibility.HIDDEN
     kind, _, arg = body.partition(":")
-    if kind in ("local", "polyglot") and arg:
+    if kind in ("local", "polyglot", "mbpp") and arg:
         try:
             if kind == "local":
                 from proteus.bench.local import local_task
                 task = local_task(f"local:{arg}")
-            else:
+            elif kind == "polyglot":
                 from proteus.bench.polyglot import polyglot_task
                 task = polyglot_task(arg)
+            else:
+                from proteus.bench.mbpp import mbpp_task
+                task = mbpp_task(arg)
         except KeyError as exc:
             raise SystemExit(str(exc)) from None
         return EvaluatorSpec(name=task.id, run=as_evaluator(task), kind="benchmark",
@@ -214,7 +217,7 @@ def _evaluator(spec: str, adapter_factory):
     raise SystemExit(
         f"bad --evaluator {spec!r} "
         "(use units:<surface-name> | tool-calls | step | local:<task> | "
-        "polyglot:<exercise> "
+        "polyglot:<exercise> | mbpp:<task-id> "
         "| contains:<relpath>:<needle>, with optional @hidden/@observe)")
 
 
@@ -480,7 +483,7 @@ def main(argv=None) -> int:
     r.add_argument("--evaluator", action="append", metavar="SPEC",
                    help="attach an evaluator, repeatable: units:<surface-name> | "
                         "tool-calls | step | local:<task> | polyglot:<exercise> | "
-                        "contains:<relpath>:<needle>, each with optional @hidden "
+                        "mbpp:<task-id> | contains:<relpath>:<needle>, each with optional @hidden "
                         "(default) or @observe; at most one benchmark task per run")
     r.add_argument("--seeds", type=int, default=4)
     r.add_argument("--episodes", type=int, default=10)

--- a/tests/run_offline.py
+++ b/tests/run_offline.py
@@ -30,12 +30,13 @@ def main() -> int:
     import test_bench as B
     import test_goals as G
     import test_instrument as I
+    import test_mbpp as M
     import test_polyglot as P
     import test_selfcode as C
     import test_smoke as S
     tmp = pathlib.Path(tempfile.mkdtemp())
     passed = failed = 0
-    for mod in (G, S, A, B, I, P, C):
+    for mod in (G, S, A, B, I, M, P, C):
         for name in [n for n in dir(mod) if n.startswith("test_")]:
             fn = getattr(mod, name)
             d = tmp / mod.__name__ / name

--- a/tests/test_mbpp.py
+++ b/tests/test_mbpp.py
@@ -1,0 +1,278 @@
+"""MBPP adapter tests against a fabricated official-format dataset, without network."""
+
+import json
+import os
+from pathlib import Path
+
+
+def _mini_dataset(tmp_path: Path) -> tuple[Path, dict]:
+    record = {
+        "source_file": "fixture.json",
+        "task_id": 2,
+        "prompt": "Write a function clamp(value) that limits integers to the range 0..5.",
+        "code": "def clamp(value):\n    return min(5, max(0, value))\n",
+        "test_imports": [],
+        "test_list": [
+            "assert clamp(-1) == 0",
+            "assert clamp(2) == 2",
+            "assert clamp(10) == 5",
+        ],
+    }
+    path = tmp_path / "sanitized-mbpp.json"
+    path.write_text(json.dumps([record]), encoding="utf-8")
+    return path, record
+
+
+def _seed_task(tmp_path: Path):
+    from proteus.bench.mbpp import mbpp_task
+
+    dataset, record = _mini_dataset(tmp_path)
+    task = mbpp_task(2, dataset_file=dataset)
+    ws = tmp_path / "task"
+    ws.mkdir()
+    task.setup(ws)
+    return task, ws, record
+
+
+def test_lists_and_seeds_only_public_task_material(tmp_path):
+    from proteus.bench.mbpp import list_tasks, mbpp_task
+
+    dataset, record = _mini_dataset(tmp_path)
+    assert list_tasks(dataset) == ["2"]
+
+    task = mbpp_task(2, dataset_file=dataset)
+    ws = tmp_path / "task"
+    ws.mkdir()
+    task.setup(ws)
+
+    assert task.id == "mbpp:2"
+    assert sorted(path.name for path in ws.iterdir()) == ["README.md", "solution.py"]
+    seeded = "\n".join(path.read_text(encoding="utf-8") for path in ws.iterdir())
+    assert record["prompt"] in seeded
+    assert record["code"].strip() not in seeded
+    assert not any(test in seeded for test in record["test_list"])
+
+
+def test_default_dataset_downloads_to_cache_once(tmp_path):
+    import io
+    from unittest.mock import patch
+
+    from proteus.bench.mbpp import dataset_path, list_tasks
+
+    fixture, _ = _mini_dataset(tmp_path)
+    payload = fixture.read_bytes()
+    old_home = os.environ.get("HOME")
+    old_dataset = os.environ.pop("PROTEUS_MBPP_PATH", None)
+    os.environ["HOME"] = str(tmp_path / "home")
+    try:
+        with patch("proteus.bench.mbpp.request.urlopen", return_value=io.BytesIO(payload)) as get:
+            first = dataset_path()
+            second = dataset_path()
+        assert first == second and first.is_file()
+        assert list_tasks(first) == ["2"]
+        assert get.call_count == 1
+    finally:
+        if old_home is None:
+            os.environ.pop("HOME", None)
+        else:
+            os.environ["HOME"] = old_home
+        if old_dataset is not None:
+            os.environ["PROTEUS_MBPP_PATH"] = old_dataset
+
+
+def test_seeded_stub_fails_all_held_out_tests(tmp_path, trusted_grader):
+    task, ws, _ = _seed_task(tmp_path)
+    result = task.grade(ws, sandbox=trusted_grader)
+    assert result.score == 0.0 and not result.passed
+    assert "0/3" in result.detail
+
+
+def test_canonical_solution_scores_full(tmp_path, trusted_grader):
+    task, ws, record = _seed_task(tmp_path)
+    (ws / "solution.py").write_text(record["code"], encoding="utf-8")
+    result = task.grade(ws, sandbox=trusted_grader)
+    assert result.score == 1.0 and result.passed
+    assert "3/3" in result.detail
+
+
+def test_reference_imports_needed_by_assertions_stay_in_trusted_parent(
+    tmp_path, trusted_grader
+):
+    from proteus.bench.mbpp import mbpp_task
+
+    record = {
+        "source_file": "fixture.json",
+        "task_id": 596,
+        "prompt": "Write a function that returns the byte size of a tuple.",
+        "code": "import sys\ndef tuple_size(value):\n    return sys.getsizeof(value)\n",
+        "test_imports": [],
+        "test_list": [
+            "assert tuple_size(('A', 1)) == sys.getsizeof(('A', 1))",
+        ],
+    }
+    dataset = tmp_path / "imports.json"
+    dataset.write_text(json.dumps([record]), encoding="utf-8")
+    task = mbpp_task(596, dataset_file=dataset)
+    ws = tmp_path / "imports-task"
+    ws.mkdir()
+    task.setup(ws)
+    (ws / "solution.py").write_text(record["code"], encoding="utf-8")
+    result = task.grade(ws, sandbox=trusted_grader)
+    assert result.score == 1.0 and result.passed
+
+
+def test_opaque_return_values_preserve_truthiness(tmp_path, trusted_grader):
+    from proteus.bench.mbpp import mbpp_task
+
+    record = {
+        "source_file": "fixture.json",
+        "task_id": 737,
+        "prompt": "Write a function that checks whether a string starts with a vowel.",
+        "code": "import re\ndef starts_vowel(text):\n    return re.match(r'^[aeiou]', text)\n",
+        "test_imports": [],
+        "test_list": ["assert starts_vowel('annie')", "assert not starts_vowel('bob')"],
+    }
+    dataset = tmp_path / "opaque.json"
+    dataset.write_text(json.dumps([record]), encoding="utf-8")
+    task = mbpp_task(737, dataset_file=dataset)
+    ws = tmp_path / "opaque-task"
+    ws.mkdir()
+    task.setup(ws)
+    (ws / "solution.py").write_text(record["code"], encoding="utf-8")
+    result = task.grade(ws, sandbox=trusted_grader)
+    assert result.score == 1.0 and result.passed
+
+
+def test_incomplete_solution_gets_dense_partial_score(tmp_path, trusted_grader):
+    task, ws, _ = _seed_task(tmp_path)
+    (ws / "solution.py").write_text(
+        "def clamp(value):\n    return max(0, value)\n", encoding="utf-8"
+    )
+    result = task.grade(ws, sandbox=trusted_grader)
+    assert result.score == 2 / 3 and not result.passed
+    assert "2/3" in result.detail
+
+
+def test_agent_cannot_replace_the_held_out_grader(tmp_path, trusted_grader):
+    task, ws, _ = _seed_task(tmp_path)
+    (ws / "_grade.py").write_text(
+        'print("{\\"total\\": 3, \\"passed\\": 3}")\n', encoding="utf-8"
+    )
+    result = task.grade(ws, sandbox=trusted_grader)
+    assert result.score == 0.0 and not result.passed
+    assert not (ws / "_grade.py").exists()
+
+
+def test_candidate_cannot_disable_assertions_by_patching_exec(tmp_path, trusted_grader):
+    task, ws, _ = _seed_task(tmp_path)
+    (ws / "solution.py").write_text(
+        "import builtins\nbuiltins.exec = lambda *args, **kwargs: None\n", encoding="utf-8"
+    )
+    result = task.grade(ws, sandbox=trusted_grader)
+    assert result.score == 0.0 and not result.passed
+
+
+def test_candidate_cannot_reach_trusted_control_through_frames(tmp_path, trusted_grader):
+    task, ws, _ = _seed_task(tmp_path)
+    (ws / "solution.py").write_text(
+        "import sys\n"
+        "caller = sys._getframe(1).f_globals\n"
+        "caller['trusted_exec'] = lambda *args, **kwargs: None\n",
+        encoding="utf-8",
+    )
+    result = task.grade(ws, sandbox=trusted_grader)
+    assert result.score == 0.0 and not result.passed
+
+
+def test_task_local_module_cannot_shadow_trusted_grader_imports(tmp_path, trusted_grader):
+    task, ws, _ = _seed_task(tmp_path)
+    (ws / "base64.py").write_text(
+        "import os\nimport sys\n"
+        "frame = sys._getframe()\n"
+        "while frame is not None:\n"
+        "    scope = frame.f_globals\n"
+        "    if 'REPORT_PREFIX' in scope and 'TESTS' in scope:\n"
+        "        total = len(scope['TESTS'])\n"
+        "        sys.stdout.write(scope['REPORT_PREFIX'] + f'{total}/{total}\\n')\n"
+        "        sys.stdout.flush()\n"
+        "        os._exit(0)\n"
+        "    frame = frame.f_back\n"
+        "raise ImportError('trusted parent not found')\n",
+        encoding="utf-8",
+    )
+    result = task.grade(ws, sandbox=trusted_grader)
+    assert result.score == 0.0 and not result.passed
+
+
+def test_candidate_cannot_forge_a_late_json_report(tmp_path, trusted_grader):
+    task, ws, _ = _seed_task(tmp_path)
+    (ws / "solution.py").write_text(
+        "import atexit\n"
+        "atexit.register(lambda: print('{\"total\": 3, \"passed\": 3}'))\n",
+        encoding="utf-8",
+    )
+    result = task.grade(ws, sandbox=trusted_grader)
+    assert result.score == 0.0 and not result.passed
+
+
+def test_candidate_early_exit_cannot_pass(tmp_path, trusted_grader):
+    task, ws, _ = _seed_task(tmp_path)
+    (ws / "solution.py").write_text("import os\nos._exit(0)\n", encoding="utf-8")
+    result = task.grade(ws, sandbox=trusted_grader)
+    assert result.score == 0.0 and not result.passed
+
+
+def test_unavailable_sandbox_returns_legible_zero(tmp_path):
+    class UnavailableSandbox:
+        def run(self, *args, **kwargs):
+            raise FileNotFoundError("docker unavailable")
+
+    task, ws, _ = _seed_task(tmp_path)
+    result = task.grade(ws, sandbox=UnavailableSandbox())
+    assert result.score == 0.0 and not result.passed
+    assert "secure grader unavailable" in result.detail
+
+
+def test_malformed_grader_report_returns_zero(tmp_path):
+    import subprocess
+
+    class MalformedSandbox:
+        def run(self, *args, **kwargs):
+            return subprocess.CompletedProcess(["python", "_grade.py"], 0, "noise\n", "")
+
+    task, ws, _ = _seed_task(tmp_path)
+    result = task.grade(ws, sandbox=MalformedSandbox())
+    assert result.score == 0.0 and not result.passed
+    assert "no report" in result.detail
+
+
+def test_none_grader_streams_return_zero_instead_of_raising(tmp_path):
+    import subprocess
+
+    class NoneStreamsSandbox:
+        def run(self, *args, **kwargs):
+            return subprocess.CompletedProcess(["python", "_grade.py"], 0, None, None)
+
+    task, ws, _ = _seed_task(tmp_path)
+    result = task.grade(ws, sandbox=NoneStreamsSandbox())
+    assert result.score == 0.0 and not result.passed
+    assert "no report" in result.detail
+
+
+def test_cli_resolves_mbpp_task(tmp_path):
+    from proteus.cli import _evaluator
+
+    dataset, _ = _mini_dataset(tmp_path)
+    old_dataset = os.environ.get("PROTEUS_MBPP_PATH")
+    os.environ["PROTEUS_MBPP_PATH"] = str(dataset)
+    try:
+        spec, task = _evaluator("mbpp:2@observe", lambda: None)
+    finally:
+        if old_dataset is None:
+            os.environ.pop("PROTEUS_MBPP_PATH", None)
+        else:
+            os.environ["PROTEUS_MBPP_PATH"] = old_dataset
+
+    assert spec.kind == "benchmark" and spec.visibility.value == "observe"
+    assert task is not None and task.id == "mbpp:2"
+    assert spec.name == task.id


### PR DESCRIPTION
## Summary

- add the official Google Research sanitized MBPP dataset as a lightweight `BenchTask` pack
- expose `list_tasks()` and `mbpp_task()`, with explicit path, `PROTEUS_MBPP_PATH`, and atomic cache download support
- seed only the prompt and `solution.py`, keeping canonical code and assertions out of the task workspace
- grade each assertion independently for dense scores through the existing sandbox boundary
- isolate trusted assertions and reporting from candidate code with a parent/worker process boundary and Python isolated mode
- add `mbpp:<task-id>` CLI routing, benchmark docs, and offline-runner coverage

## Safety properties

Candidate code runs only in worker processes and receives function names plus encoded inputs. The trusted parent holds the assertions, unlinks its transient grader before candidate execution, safely decodes only tagged primitive/container values, and uses `python -I` so task-local modules cannot shadow trusted imports. Missing code, timeouts, malformed output, early exits, unavailable isolation, patched builtins, frame inspection, forged reports, and module-shadowing attempts all score zero rather than falling back to host execution.

## Verification

- `ruff check .`
- `pytest tests/ -q` — 144 passed, 1 skipped
- `python tests/run_offline.py` — 128 passed, 0 failed
- official `sanitized-mbpp.json` discovery — 427 tasks
- real task `mbpp:2` spot check — seeded stub 0/3; official canonical solution 3/3
- exhaustive compatibility check — 427/427 official canonical solutions pass

The real-data checks used the repository test-only trusted runner because the local Docker daemon was unavailable. Production grading still has no host fallback and requires the configured secure sandbox.

Dataset source: Google Research MBPP, `sanitized-mbpp.json`, Apache License 2.0.
