### PR TITLE
fix(dsh): validate fresh headless cold starts

### DIFF
--- a/docs/ADAPTERS.md
+++ b/docs/ADAPTERS.md
@@ -267,24 +267,28 @@ natively —
    is exactly the tracked source of the build it boots). The image's entrypoint syncs
    the agent's copy over the baked tree at boot, rebuilds with the project's own
    toolchain when the source hash changes (outputs cached on `/state`; an untouched copy
-   boots via a pristine-hash fast path), and execs the built CLI. Dependencies stay in
-   the image: they are apparatus, like the interpreter.
+   boots via a pristine-hash fast path), and execs the built CLI. External dependency
+   bytes stay in the image as apparatus. DSH may evolve package manifests and workspace
+   packages only when its frozen lockfile remains consistent and every required external
+   package is already present in the image's offline pnpm store.
 2. At episode N, every phase mounts the same last-valid snapshot read-only at `/workspace`.
    The writable `harness/` candidate is a separate `/workspace/candidate` mount. The boot
    wrapper syncs only active `/workspace/src`, so an act edit cannot control reflect. The
    agent may inspect its candidate, but activation waits for episode N+1.
 3. `src/` is a declared surface (`loop`, `is_code=True`), inside the snapshot repo — code
    edits are versioned per episode and measured with the same ruler as notes and tools.
-4. After reflect, `validate_candidate()` runs `--version` through the candidate boot path —
-   the **model-free viability gate**. For pi that includes the rebuild, so a type error the
-   agent wrote surfaces with the build log tail. A failed candidate cannot activate: the
-   active line rolls back and remains healthy, while the exact failed tree is restored as
-   episode N+1's writable repair candidate. A passing candidate first runs as the
-   controlling harness one episode later.
+4. After reflect, `validate_candidate()` runs the **model-free viability gate**. Pi rebuilds
+   and probes `--version`. DSH performs a frozen offline dependency relink and rebuild in
+   one container, then starts the exact headless profile from the saved cache in a second,
+   fresh container. This catches stale lockfiles, missing package links, newly added package
+   outputs omitted from a cache, and plugin-load failures before activation. A failed
+   candidate cannot activate: the active line rolls back and remains healthy, while the
+   exact failed tree is restored as episode N+1's writable repair candidate. A passing
+   candidate first runs as the controlling harness one episode later.
 
 Verified live for both harnesses: a marker written into the real TypeScript entry point
 (`packages/coding-agent/src/cli.ts` for pi, `apps/cli/src/bin.ts` for dsh) appears on the
-next boot after the automatic in-container rebuild; the second boot hits the dist cache;
+next boot after the automatic in-container rebuild; a later boot hits the dist cache;
 and a planted TS type error is refused by the gate (exit 97 with the build log tail) and
 automatically restored to the prior valid snapshot. The Docker image itself is baked once per harness version
 and never rebuilt during a run — per episode, an unchanged source boots via the fast

--- a/docs/EPISODE.md
+++ b/docs/EPISODE.md
@@ -190,9 +190,15 @@ instrumenting the harness. Path→surface attribution is the adapter's mapping
 ### 5. Boundary viability gate — framework + adapter
 
 After reflect, and only then, Proteus calls the optional model-free
-`validate_candidate(harness_root)`. DSH and Pi exact-sync the candidate through their
-normal image boot path, rebuild it, and run `--version`. The candidate still does not
-control a model session.
+`validate_candidate(harness_root)`. Pi exact-syncs the candidate through its normal image
+boot path, rebuilds it, and runs `--version`. DSH first recreates workspace links with a
+frozen offline dependency install when its dependency-input hash changed, rebuilds and
+dynamically caches every discovered package `lib/`, then runs `--version`. It next opens a
+**second, fresh container** and boots the exact headless profile from that cache with an
+isolated home and no provider credential.
+Reaching the deterministic missing-credential boundary proves the plugin graph loaded; a
+missing package, stale lockfile, uncached dependency, or headless startup error rejects the
+candidate. The candidate never controls a model session during either probe.
 
 - **pass**: the candidate may proceed to evaluators and selection, then becomes eligible
   to activate in episode N+1;
@@ -312,7 +318,7 @@ evolved memory. Raw conversation and process state never survive.
 | `run_episode()` | how the four phases execute | in-process / one container per phase / delegated |
 | `read_trace()` | each harness's log format → `ActionEvent`s | JSONL / zstd JSONL / session events |
 | `required_edit_tools()` | evidence the harness can still edit itself | write / write+edit |
-| `validate_candidate()` | optional model-free boundary viability gate | dsh/pi: rebuild + `--version` |
+| `validate_candidate()` | optional model-free boundary viability gate | pi: rebuild + `--version`; dsh: frozen offline dependency check + rebuild, then fresh-container headless cold start |
 | `disposition_in_files` | skip the prompt channel (double-dose guard) | True for dsh/pi |
 | the self-code arrangement | how the harness's own code becomes an evolvable surface | aki: `sys.path`-first copy; dsh/pi: run-local real source rebuilt at boot |
 

--- a/docs/RECIPES.md
+++ b/docs/RECIPES.md
@@ -92,11 +92,14 @@ proteus run --harness dsh \
 
 For both source adapters, an unchanged source takes a pristine fast path. A changed source
 is exact-synced, rebuilt once per source hash, cached under `/state`, and rejected by the
-post-reflect viability gate if it cannot boot. Every phase within an episode runs the same
-frozen snapshot; a valid candidate activates only in the next episode, while an invalid one
-is blocked from activation and restored as the next episode's writable repair base. The
-running harness remains the last-valid snapshot. Containers run as the host uid/gid so
-their bind-mounted files remain editable on Linux.
+post-reflect viability gate if it cannot boot. DSH additionally checks the frozen lockfile
+against the image's offline pnpm store, dynamically includes new workspace-package outputs
+in that cache, and repeats startup in a fresh container using the real headless profile.
+Every phase within an episode runs the same frozen snapshot; a valid candidate activates
+only in the next episode, while an invalid one is blocked from activation and restored as
+the next episode's writable repair base. The running harness remains the last-valid
+snapshot. Containers run as the host uid/gid so their bind-mounted files remain editable
+on Linux.
 
 ### Long-form source evolution budget
 

--- a/environments/dsh-src/Dockerfile
+++ b/environments/dsh-src/Dockerfile
@@ -9,7 +9,15 @@ WORKDIR /opt/src
 # NOTE: bake with `docker build --network host` on macOS — the default bridge goes
 # through vpnkit NAT, whose connections exhaust under pnpm's parallel registry fetches
 # (the same reason runtime containers use host networking).
-RUN corepack enable && pnpm install --frozen-lockfile
+# Keep both Corepack's package-manager cache and pnpm's content store outside /root.
+# Runtime validation runs as the host uid, so a cache under root's HOME would appear
+# empty and Corepack would try to download pnpm again during an offline cold start.
+ENV COREPACK_HOME=/opt/corepack
+RUN corepack enable && pnpm install --frozen-lockfile --store-dir /opt/pnpm-store \
+    --config.trust-lockfile=true
+# Candidates may use only the package-manager version baked for the pinned seed. A
+# packageManager change is a dependency change too and must fail closed, not reach out.
+ENV COREPACK_ENABLE_NETWORK=0
 RUN npm run build:lib
 COPY .proteus-boot.sh /usr/local/bin/dsh-boot
 RUN chmod +x /usr/local/bin/dsh-boot
@@ -18,12 +26,14 @@ RUN git archive --format=tar -o /opt/dsh-source.tar HEAD \
  && tar -tf /opt/dsh-source.tar | grep -v '/$' > /opt/source-manifest.txt \
  && mkdir /tmp/pristine && tar -xf /opt/dsh-source.tar -C /tmp/pristine \
  && dsh-boot --proteus-tree-hash /tmp/pristine > /opt/pristine-hash \
+ && dsh-boot --proteus-dependency-hash /tmp/pristine > /opt/pristine-dependency-hash \
  && rm -rf /tmp/pristine
 ENV DSH_HOME=/state
 ENV DSH_TELEMETRY_MODE=DISABLED
 # the boot wrapper syncs and rebuilds inside /opt/src as whatever uid the host runs
 # the container with — the tree must be writable by any user
-RUN chmod -R a+rwX /opt/src && chmod a+r /opt/pristine-hash /opt/source-manifest.txt \
+RUN chmod -R a+rwX /opt/src /opt/corepack /opt/pnpm-store \
+ && chmod a+r /opt/pristine-hash /opt/pristine-dependency-hash /opt/source-manifest.txt \
  && chmod a+r /opt/*.tar
 WORKDIR /workspace
 ENTRYPOINT ["dsh-boot"]

--- a/environments/dsh-src/README.md
+++ b/environments/dsh-src/README.md
@@ -3,10 +3,11 @@
 Same design as [`environments/pi-src/`](../pi-src/README.md): the image bakes a
 deepseek-harness monorepo checkout at the pinned tag (dependencies installed, `build:lib`
 run once), and `boot.sh` syncs the agent's copy from `/workspace/src` over the baked
-tree, rebuilds with the project's own toolchain when the source hash changes (outputs
-cached on `/state`), and execs the built CLI (`apps/cli/lib/bin.js`). The source tar the
-adapter extracts is produced by `git archive`, so the seed's `src/` is exactly the
-tracked source of the build it boots.
+tree, recreates workspace links from a frozen lockfile and offline package store, rebuilds
+with the project's own toolchain when the source hash changes (outputs cached on `/state`),
+and execs the built CLI (`apps/cli/lib/bin.js`). The source tar the adapter extracts is
+produced by `git archive`, so the seed's `src/` is exactly the tracked source of the build
+it boots.
 
 Rebuild:
 
@@ -24,9 +25,22 @@ docker build --network host -f environments/dsh-src/Dockerfile \
 ```
 
 An untouched source takes the pristine fast path without copying or rebuilding. A changed
-source is exact-synced and pays one in-container `build:lib` per distinct source hash;
-subsequent boots of that source state reuse `/state` while still syncing runtime-read files
-such as `config/`.
+source is exact-synced and pays one in-container `build:lib` per distinct source hash. A
+separate dependency-input hash covers package manifests, pnpm workspace/lock configuration,
+and patches: pure code edits keep the baked links, while a changed dependency graph must
+pass `pnpm install --offline --frozen-lockfile`. Build outputs are discovered only after
+the evolved workspace is present, so a newly added package's `lib/` is included in the
+cache. Subsequent boots recreate generated workspace links when needed, reuse the cached
+outputs from `/state`, and still sync runtime-read files such as `config/`. A manifest
+change without a matching `pnpm-lock.yaml`, an uncached package-manager version, or an
+external dependency absent from the image's pnpm store fails closed without network access.
+
+The DSH adapter's boundary gate uses two containers. The first performs that dependency
+check, build, cache write, and `--version` probe. The second starts from the clean image,
+reloads the exact cache, and boots the headless profile with an isolated home and no model
+credential. A normal exit or the expected missing-credential boundary after plugin loading
+is accepted. Rebuild this image after changing `Dockerfile` or `boot.sh`; an older image
+does not implement the cold-start contract.
 
 Attribution: deepseek-harness (github.com/deepseek-ai/deepseek-harness), MIT.
 

--- a/environments/dsh-src/boot.sh
+++ b/environments/dsh-src/boot.sh
@@ -9,20 +9,37 @@
 # rename, an empty file, a deletion, or a boundary-preserving multi-file edit changes it. An
 # untouched copy takes the pristine fast path with no copying at all. Build outputs are
 # cached on /state keyed by the hash. The overlay excludes an agent-installed
-# node_modules so it cannot shadow the baked dependencies.
+# node_modules so it cannot shadow the baked dependencies. A changed tree is relinked
+# against the image's offline pnpm store with a frozen lockfile before it can build; this
+# lets a candidate add workspace packages without silently inheriting stale links, while
+# rejecting undeclared or unavailable dependencies without network access.
 set -e
 
 # Hash every path and payload as a length-framed record. Concatenating all file contents
 # before the path list is ambiguous: {one="ab", two="c"} and {one="a", two="bc"}
 # produce the same byte stream. Symlink targets are part of the tree as well.
 tree_hash() {
-    node - "$1" <<'JS'
+    node - "$1" "${2:-all}" <<'JS'
 const crypto = require("crypto");
 const fs = require("fs");
 const path = require("path");
 
 const root = path.resolve(process.argv[2]);
+const mode = process.argv[3];
 const hash = crypto.createHash("sha256");
+
+function isDependencyInput(relative) {
+    const basename = path.posix.basename(relative);
+    return basename === "package.json"
+        || relative === "pnpm-lock.yaml"
+        || relative === "pnpm-workspace.yaml"
+        || relative === ".npmrc"
+        || relative === ".pnpmfile.cjs"
+        || relative === ".pnpmfile.mjs"
+        || relative === "pnpmfile.cjs"
+        || relative === "pnpmfile.mjs"
+        || relative.startsWith("patches/");
+}
 
 function record(kind, relative, payload) {
     const name = Buffer.from(relative, "utf8");
@@ -48,11 +65,15 @@ function walk(directory, relative = "") {
         const child = path.join(directory, entry.name);
         const stat = fs.lstatSync(child);
         if (stat.isSymbolicLink()) {
-            record("L", childRelative, Buffer.from(fs.readlinkSync(child), "utf8"));
+            if (mode === "all" || isDependencyInput(childRelative)) {
+                record("L", childRelative, Buffer.from(fs.readlinkSync(child), "utf8"));
+            }
         } else if (stat.isDirectory()) {
             walk(child, childRelative);
         } else if (stat.isFile()) {
-            record(stat.mode & 0o111 ? "X" : "F", childRelative, fs.readFileSync(child));
+            if (mode === "all" || isDependencyInput(childRelative)) {
+                record(stat.mode & 0o111 ? "X" : "F", childRelative, fs.readFileSync(child));
+            }
         } else {
             throw new Error(`unsupported source entry: ${childRelative}`);
         }
@@ -69,13 +90,18 @@ if [ "${1:-}" = "--proteus-tree-hash" ]; then
     tree_hash "$2"
     exit 0
 fi
+if [ "${1:-}" = "--proteus-dependency-hash" ]; then
+    [ "$#" -eq 2 ] || { echo "usage: $0 --proteus-dependency-hash DIR" >&2; exit 2; }
+    tree_hash "$2" dependencies
+    exit 0
+fi
 
 # the container may run as an arbitrary host uid: give npm a writable HOME
 export HOME=/tmp
+export COREPACK_ENABLE_NETWORK=0
 SRC=/opt/src
 CLI=$SRC/apps/cli/lib/bin.js
-DISTS=$(cd "$SRC" && find apps packages vendor -type d -name lib -not -path '*/node_modules/*' 2>/dev/null | tr '
-' ' ')
+PNPM_STORE=/opt/pnpm-store
 
 if [ -d /workspace/src/apps ]; then
     HASH=$(tree_hash /workspace/src)
@@ -98,10 +124,36 @@ if [ -d /workspace/src/apps ]; then
         # Cache hits and rebuilds must start from the same compiled tree. Otherwise a
         # deleted/renamed source can leave a loadable lib/*.js ghost from an earlier boot.
         (cd "$SRC" && {
+        # build:lib owns these three source tiers. Native launcher artifacts are baked
+        # apparatus and deliberately excluded: the upstream build does not regenerate
+        # them, so deleting their lib/ directories would break an otherwise valid boot.
         find apps packages vendor -type d -name lib -not -path '*/node_modules/*' \
             -exec rm -rf {} + 2>/dev/null || true
         find . -name '*.tsbuildinfo' -not -path './node_modules/*' -delete 2>/dev/null || true
         })
+        mkdir -p /state
+        DEP_HASH=$(tree_hash /workspace/src dependencies)
+        if [ "$DEP_HASH" != "$(cat /opt/pristine-dependency-hash)" ]; then
+            # package.json / workspace topology is part of the evolvable source, while
+            # node_modules is image apparatus. Re-resolve in the disposable image tree so
+            # a new workspace package gets real runtime links. Frozen + offline means the
+            # candidate must keep pnpm-lock.yaml aligned and cannot fetch an unpinned
+            # package. Pure code edits retain the baked dependency links and skip this
+            # work entirely.
+            #
+            # pnpm 11 verifies its default release-age policy with registry metadata even
+            # under --offline. The candidate lockfile is instead constrained by a frozen
+            # manifest match plus the image's immutable, integrity-checked content store;
+            # trust-lockfile disables only that network-backed metadata pass.
+            if ! (cd "$SRC" && CI=1 pnpm install --offline --frozen-lockfile \
+                    --config.trust-lockfile=true \
+                    --ignore-scripts --store-dir "$PNPM_STORE" \
+                    >/state/last-dependency-check.log 2>&1); then
+                echo "self-edited dependency graph is not reproducible from the frozen offline store:" >&2
+                tail -30 /state/last-dependency-check.log >&2
+                exit 96
+            fi
+        fi
         if [ -f "/state/dist-$HASH.tar" ]; then
             tar -xf "/state/dist-$HASH.tar" -m --no-same-permissions -C "$SRC"
         else
@@ -110,10 +162,43 @@ if [ -d /workspace/src/apps ]; then
                 tail -20 /state/last-build.log >&2
                 exit 97
             fi
-            mkdir -p /state
-            (cd "$SRC" && find $DISTS -type f -print0 \
-                | tar -cf "/state/dist-$HASH.tar" --null -T -)
+            # Discover outputs only after the evolved tree has been overlaid and built.
+            # A directory list captured from the baked baseline omits every package the
+            # candidate adds, producing a cache that passes in the build container but
+            # cannot cold-start in the next one.
+            CACHE_TMP="/state/.dist-$HASH.$$.tar"
+            (cd "$SRC" && find apps packages vendor \
+                -path '*/node_modules' -prune -o \
+                \( -type f -o -type l \) -path '*/lib/*' -print0 2>/dev/null \
+                | tar -cf "$CACHE_TMP" --null -T -)
+            mv "$CACHE_TMP" "/state/dist-$HASH.tar"
         fi
     fi
+fi
+
+# A version probe exercises argument parsing, not the headless plugin tree. The adapter
+# invokes this mode in a *second* container after the build probe, so it also verifies that
+# the cached outputs and regenerated workspace links survive a true cold start. An empty,
+# isolated DSH_HOME and no provider credential make the expected terminal state a
+# MISSING_CREDENTIAL error after successful plugin loading — no model call is possible.
+if [ "${1:-}" = "--proteus-headless-smoke" ]; then
+    PROBE_ROOT=$(mktemp -d)
+    set +e
+    (
+        unset DEEPSEEK_API_KEY DEEPSEEK_KEY
+        export DSH_HOME="$PROBE_ROOT/home"
+        mkdir -p "$DSH_HOME"
+        node "$CLI" --profile headless "Proteus cold-start validation."
+    ) >"$PROBE_ROOT/stdout" 2>"$PROBE_ROOT/stderr"
+    PROBE_RC=$?
+    set -e
+    if [ "$PROBE_RC" -eq 0 ] \
+            || grep -q 'MISSING_CREDENTIAL' "$PROBE_ROOT/stdout" "$PROBE_ROOT/stderr"; then
+        exit 0
+    fi
+    echo "self-edited source fails a fresh headless-profile cold start:" >&2
+    tail -40 "$PROBE_ROOT/stderr" >&2
+    tail -20 "$PROBE_ROOT/stdout" >&2
+    exit 98
 fi
 exec node "$CLI" "$@"

--- a/proteus/adapters/dsh.py
+++ b/proteus/adapters/dsh.py
@@ -49,6 +49,10 @@ PHASE_TIMEOUT_S = 600
 SOURCE_TAR = "/opt/dsh-source.tar"
 #: A full build:lib is ~330s; the gate's timeout must cover one on a changed source.
 BOOT_TIMEOUT_S = 900
+#: A 246-package DSH workspace takes roughly 90s to relink and cold-start on Docker
+#: Desktop even with a warm offline store. Keep enough headroom for slower hosts while
+#: still treating a genuine hang as a runtime viability failure.
+COLD_BOOT_TIMEOUT_S = 300
 SEED_INSTRUCTIONS = """\
 # Agent instructions
 
@@ -70,12 +74,14 @@ Proteus supplies the cross-phase operational handoff at
 runtime context outside the evolving snapshot; do not copy credentials or raw tool output
 into it.
 
-The image already contains an installed, built copy at `/opt/src`. Do not run `pnpm
-install` in either workspace, and do not create `node_modules` or package-manager caches
-in the candidate: those are generated dependencies, not evolution, and would pollute the
-persistent snapshot. `/opt/src` is the build of the frozen active snapshot. Do not sync,
-reload, or execute candidate source during a phase; Proteus owns the model-free boundary
-build and viability gate after reflect.
+The image already contains an installed, built copy at `/opt/src`. Do not create or persist
+`node_modules` or package-manager caches in the candidate: those are generated dependencies,
+not evolution, and would pollute the snapshot. You may add workspace packages or change
+package manifests, but keep `pnpm-lock.yaml` aligned. The boundary gate recreates links with
+a frozen offline install, so an inconsistent lockfile or a dependency absent from the baked
+store is rejected for repair. `/opt/src` is the build of the frozen active snapshot. Do not
+sync, reload, or execute candidate source during a phase; Proteus owns the model-free
+boundary build and viability gate after reflect.
 
 Each session is one phase of an episode. Harness files and the bounded Proteus handoff
 carry over; the raw conversation does not.
@@ -245,20 +251,42 @@ class DshHarness:
         return ((str(task), "/workspace/task"),) if task.is_dir() else ()
 
     def check_boot(self, harness_root: Path) -> str:
-        """Viability gate: sync + rebuild + `--version` through the image's boot wrapper.
+        """Build once, then cold-start the exact headless runtime in a fresh container.
 
-        The wrapper rebuilds from /workspace/src, so a type error the agent wrote into
-        its own source surfaces here as a legible build failure (exit 97 with the build
-        log tail), before any API spend. The timeout covers one full build:lib."""
+        The first probe exact-syncs the candidate, validates its dependency graph offline,
+        rebuilds it, writes the dist cache, and runs ``--version``. A second sandbox call
+        starts from a clean image, reloads that cache, and boots the headless plugin tree
+        without provider credentials. Keeping the probes in separate containers is
+        essential: a newly-added workspace package can compile in the build container yet
+        be absent from the cached outputs or runtime links used by episode N+1.
+        """
         harness = Path(harness_root)
         state = harness.parent / ".dsh-state"
         state.mkdir(exist_ok=True)
-        proc = self.sandbox.run(
-            harness.parent, ["--version"], env={}, timeout_s=BOOT_TIMEOUT_S,
-            mounts=((str(harness), "/workspace"), (str(state), "/state")))
+        mounts = ((str(harness), "/workspace"), (str(state), "/state"))
+        try:
+            proc = self.sandbox.run(
+                harness.parent, ["--version"], env={}, timeout_s=BOOT_TIMEOUT_S,
+                mounts=mounts)
+        except subprocess.TimeoutExpired:
+            return f"self-edited source build timed out after {BOOT_TIMEOUT_S}s"
         if proc.returncode != 0:
             return (f"self-edited source does not boot (exit {proc.returncode}): "
-                    f"{(proc.stderr or proc.stdout)[-400:]}")
+                    f"{(proc.stderr or proc.stdout)[-1200:]}")
+        try:
+            cold = self.sandbox.run(
+                harness.parent, ["--proteus-headless-smoke"], env={},
+                timeout_s=COLD_BOOT_TIMEOUT_S, mounts=mounts)
+        except subprocess.TimeoutExpired:
+            return ("self-edited source headless cold start timed out after "
+                    f"{COLD_BOOT_TIMEOUT_S}s")
+        if cold.returncode != 0:
+            detail = (cold.stderr or cold.stdout)[-1200:]
+            if "proteus-headless-smoke" in detail and "unknown option" in detail.lower():
+                return ("DSH source image predates the headless cold-start contract; "
+                        "rebuild environments/dsh-src before running evolution")
+            return (f"self-edited source fails headless cold start "
+                    f"(exit {cold.returncode}): {detail}")
         return ""
 
     def validate_candidate(self, harness_root: Path) -> str:

--- a/scripts/smoke_check.py
+++ b/scripts/smoke_check.py
@@ -12,7 +12,8 @@ Checks, per run in the sweep:
      either stay under it or carry the turn_capped flag;
   6. a non-neutral arm has a non-empty disposition fingerprint;
   7. harnesses with a self-code surface: src/ is in the episode-0 snapshot, the evolved
-     copy still boots, a planted error is refused by the gate, and restoring clears it.
+     copy passes its complete viability contract (including DSH's fresh headless cold
+     start), a planted error is refused by the gate, and restoring clears it.
 
 Exit code = number of failed checks. Prints one line per check per run.
 """

--- a/tests/test_selfcode.py
+++ b/tests/test_selfcode.py
@@ -15,17 +15,30 @@ from proteus.adapters.dsh import DshHarness
 from proteus.adapters.pi import PiHarness
 
 
+GATE_COMMANDS = {("--version",), ("--proteus-headless-smoke",)}
+
+
+def _is_gate(call):
+    return tuple(call["command"]) in GATE_COMMANDS
+
+
 class FakeSandbox:
-    def __init__(self, boot_rc=0):
+    def __init__(self, boot_rc=0, cold_rc=0):
         self.boot_rc = boot_rc
+        self.cold_rc = cold_rc
         self.calls = []
 
     def run(self, run_root, command, env, timeout_s, mounts=(), stop_check=None):
         self.calls.append({"command": command, "mounts": mounts,
                            "stop_check": stop_check, "env": env})
-        if command != ["--version"] and stop_check is not None and stop_check():
+        if tuple(command) not in GATE_COMMANDS and stop_check is not None and stop_check():
             return subprocess.CompletedProcess(command, 137, "", "killed")
-        rc = self.boot_rc if command == ["--version"] else 0
+        if command == ["--version"]:
+            rc = self.boot_rc
+        elif command == ["--proteus-headless-smoke"]:
+            rc = self.cold_rc
+        else:
+            rc = 0
         return subprocess.CompletedProcess(command, rc, "ok", "boom" if rc else "")
 
 
@@ -115,10 +128,14 @@ def test_source_mode_gates_through_the_boot_contract(tmp_path):
         root.mkdir(exist_ok=True)
         (root / "harness").symlink_to(h)
         a.run_episode(EpisodeSpec(root=root, episode=1, model="m", phase_prompts={}))
-        gate = sandbox.calls[0]
-        assert gate["command"] == ["--version"], cls.__name__
-        conts = {cont for _, cont in gate["mounts"]}
-        assert conts == {"/workspace", "/state"},             f"{cls.__name__}: the gate must run exactly the boot contract"
+        gates = [call for call in sandbox.calls if _is_gate(call)]
+        expected = (["--version"], ["--proteus-headless-smoke"]) \
+            if cls is DshHarness else (["--version"],)
+        assert [call["command"] for call in gates] == list(expected), cls.__name__
+        for gate in gates:
+            conts = {cont for _, cont in gate["mounts"]}
+            assert conts == {"/workspace", "/state"}, \
+                f"{cls.__name__}: the gate must run exactly the boot contract"
 
 
 def test_broken_self_code_fails_the_episode_legibly(tmp_path):
@@ -135,6 +152,19 @@ def test_broken_self_code_fails_the_episode_legibly(tmp_path):
         assert not res.ok and "does not boot" in res.error, cls.__name__
         # the gate ran once and no phase was attempted after it
         assert [c["command"] for c in sandbox.calls] == [["--version"]], cls.__name__
+
+
+def test_dsh_headless_cold_start_failure_is_a_viability_error(tmp_path):
+    sandbox = FakeSandbox(cold_rc=98)
+    adapter = DshHarness(key="x", sandbox=sandbox)
+    harness = tmp_path / "harness"
+    _seed_with_fake_src(adapter, harness, ("packages",))
+
+    error = adapter.check_boot(harness)
+
+    assert "fails headless cold start" in error
+    assert [call["command"] for call in sandbox.calls] == [
+        ["--version"], ["--proteus-headless-smoke"]]
 
 
 def test_dsh_permission_mode_reaches_every_phase(tmp_path):
@@ -156,7 +186,7 @@ def test_dsh_permission_mode_reaches_every_phase(tmp_path):
         phase_prompts={phase: phase for phase in ("observe", "propose", "act", "reflect")},
     ))
 
-    phase_calls = [call for call in sandbox.calls if call["command"] != ["--version"]]
+    phase_calls = [call for call in sandbox.calls if not _is_gate(call)]
     assert len(phase_calls) == 4
     assert all(call["env"]["DSH_PERMISSION_MODE"] == "danger-full-access"
                for call in phase_calls)
@@ -175,7 +205,7 @@ def test_framework_handoff_mount_is_writable_but_snapshot_external(tmp_path):
         (root / "harness").symlink_to(harness)
         adapter.run_episode(EpisodeSpec(root=root, episode=1, model="m", phase_prompts={}))
 
-        phase = next(call for call in sandbox.calls if call["command"] != ["--version"])
+        phase = next(call for call in sandbox.calls if not _is_gate(call))
         mounts = dict(phase["mounts"])
         assert mounts[str(root / ".proteus-state")] == "/workspace/.proteus"
         assert not str(root / ".proteus-state").startswith(str(harness))
@@ -198,9 +228,9 @@ def test_staged_episode_mounts_frozen_active_read_only_and_candidate_writable(tm
             root=root, episode=1, model="m", phase_prompts={}, active_root=active,
         ))
 
-        phase_calls = [call for call in sandbox.calls if call["command"] != ["--version"]]
+        phase_calls = [call for call in sandbox.calls if not _is_gate(call)]
         assert len(phase_calls) == 4
-        assert not [call for call in sandbox.calls if call["command"] == ["--version"]], \
+        assert not [call for call in sandbox.calls if _is_gate(call)], \
             "a staged episode must not preflight the writable candidate before its phases"
         assert (active / "candidate").is_dir()
         assert (active / ".proteus").is_dir()
@@ -282,6 +312,62 @@ def test_source_hash_frames_file_boundaries_and_symlinks(tmp_path):
         assert digest(script, left) != before, f"{script}: symlink target was not hashed"
 
 
+def test_dsh_boot_contract_relinks_dependencies_and_caches_new_packages():
+    script = Path("environments/dsh-src/boot.sh").read_text()
+    dockerfile = Path("environments/dsh-src/Dockerfile").read_text()
+
+    assert "pnpm install --offline --frozen-lockfile" in script
+    assert "--config.trust-lockfile=true" in script
+    assert '--store-dir "$PNPM_STORE"' in script
+    assert 'DEP_HASH=$(tree_hash /workspace/src dependencies)' in script
+    assert "pristine-dependency-hash" in script
+    assert "COREPACK_ENABLE_NETWORK=0" in script
+    assert "find $DISTS" not in script
+    assert "find apps packages vendor" in script
+    assert "Native launcher artifacts are baked" in script
+    assert "-path '*/lib/*'" in script
+    assert 'CACHE_TMP="/state/.dist-$HASH.$$.tar"' in script
+    assert '"--proteus-headless-smoke"' in script
+    assert "MISSING_CREDENTIAL" in script
+    assert "pnpm install --frozen-lockfile --store-dir /opt/pnpm-store" in dockerfile
+    assert "COREPACK_HOME=/opt/corepack" in dockerfile
+    assert "COREPACK_ENABLE_NETWORK=0" in dockerfile
+    assert "--proteus-dependency-hash" in dockerfile
+    assert "chmod -R a+rwX /opt/src /opt/corepack /opt/pnpm-store" in dockerfile
+
+
+def test_dsh_dependency_hash_ignores_code_but_tracks_package_inputs(tmp_path):
+    script = Path("environments/dsh-src/boot.sh")
+    source = tmp_path / "source"
+    package = source / "packages" / "audio"
+    patches = source / "patches"
+    package.mkdir(parents=True)
+    patches.mkdir()
+    (source / "package.json").write_text('{"packageManager":"pnpm@11.7.0"}')
+    (source / "pnpm-lock.yaml").write_text("lockfileVersion: '9.0'\n")
+    (source / "pnpm-workspace.yaml").write_text("packages: ['packages/*']\n")
+    (package / "package.json").write_text('{"name":"audio"}')
+    code = package / "index.ts"
+    code.write_text("export const version = 1;\n")
+    patch = patches / "dependency.patch"
+    patch.write_text("first\n")
+
+    def digest():
+        return subprocess.run(
+            ["sh", str(script), "--proteus-dependency-hash", str(source)],
+            capture_output=True, text=True, check=True,
+        ).stdout.strip()
+
+    baseline = digest()
+    code.write_text("export const version = 2;\n")
+    assert digest() == baseline
+    (package / "package.json").write_text('{"name":"audio","dependencies":{"x":"1"}}')
+    package_changed = digest()
+    assert package_changed != baseline
+    patch.write_text("second\n")
+    assert digest() != package_changed
+
+
 # ------------------------------------------------------------------- turn budget
 
 def test_explicit_budget_validation_is_strict():
@@ -318,7 +404,7 @@ def test_budget_stops_new_phases_exactly(tmp_path):
                                         phase_prompts={}, max_turns=10))
         assert res.ok and not res.error, cls.__name__
         assert res.counters["turn_capped"], cls.__name__
-        phases = [c for c in sandbox.calls if c["command"] != ["--version"]]
+        phases = [c for c in sandbox.calls if not _is_gate(c)]
         assert phases == [], f"{cls.__name__}: a phase ran past the budget"
 
 
@@ -339,7 +425,7 @@ def test_budget_kill_mid_phase_is_a_cap_not_an_error(tmp_path):
         assert res.ok and not res.error, \
             f"{cls.__name__}: a budget kill must be a cap, got error={res.error!r}"
         assert res.counters["turn_capped"], cls.__name__
-        phases = [c for c in sandbox.calls if c["command"] != ["--version"]]
+        phases = [c for c in sandbox.calls if not _is_gate(c)]
         assert len(phases) == 1, f"{cls.__name__}: phases continued after the kill"
 
 
@@ -354,7 +440,7 @@ def test_no_budget_means_no_watching(tmp_path):
     (root / "harness").symlink_to(h)
     a.run_episode(EpisodeSpec(root=root, episode=1, model="m", phase_prompts={},
                               max_turns=0))
-    phases = [c for c in sandbox.calls if c["command"] != ["--version"]]
+    phases = [c for c in sandbox.calls if not _is_gate(c)]
     assert phases and all(c["stop_check"] is None for c in phases)
 
 
@@ -449,7 +535,7 @@ def test_reservation_stop_is_not_an_episode_end_for_containers(tmp_path):
         (root / "harness").symlink_to(h)
         res = a.run_episode(EpisodeSpec(root=root, episode=1, model="m", phase_prompts={},
                                         max_turns=8, min_turns_per_phase=2))
-        phases = [c for c in sandbox.calls if c["command"] != ["--version"]]
+        phases = [c for c in sandbox.calls if not _is_gate(c)]
         assert len(phases) == 4, \
             f"{cls.__name__}: reservation stop ended the episode after {len(phases)} phases"
         assert res.ok and res.counters["turn_capped"], cls.__name__
@@ -575,7 +661,7 @@ def test_explicit_phase_budget_stops_container_phases_at_the_same_lines(tmp_path
             phase_turns={"observe": 2, "propose": 2, "act": 6, "reflect": 2},
             announce_budget=True, continuity_mode="framework",
         ))
-        phases = [call for call in sandbox.calls if call["command"] != ["--version"]]
+        phases = [call for call in sandbox.calls if not _is_gate(call)]
         assert len(phases) == 4, cls.__name__
         assert result.ok and result.counters["turn_capped"], cls.__name__
         assert result.counters["checkpoint_misses"] == 4, cls.__name__


### PR DESCRIPTION
Adds a two-container DSH viability gate: frozen offline dependency validation and dynamic workspace output caching in the build container, followed by a credential-free headless cold start in a fresh container. Includes dependency-input hashing, Corepack and pnpm offline caches, regression tests, documentation, and a real Episode 4 reproduction.