### PR TITLE
feat: add HumanEval benchmark tasks

### DIFF
--- a/README.md
+++ b/README.md
@@ -308,8 +308,9 @@ Where help is wanted, in one line each — the full list with difficulty tags is
 
 - **More harnesses** — Hermes Agent first (Python, built-in self-improvement surfaces),
   then SWE-agent, OpenClaw, Codex CLI, OpenHands, OpenCode, Goose.
-- **More benchmarks** — lightweight offline packs (HumanEval, MBPP, BigCodeBench-lite),
-  SWE-bench Lite/Verified wiring, and finishing sandboxed grading for `swe`.
+- **More benchmarks** — BigCodeBench-lite and a LiveCodeBench subset, SWE-bench
+  Lite/Verified wiring, and finishing sandboxed grading for `swe` (HumanEval and MBPP
+  are shipped).
 - **Analysis** — `proteus compare` for side-by-side arms/runs; an episode-atlas view.
 - **Reproducibility & cost** — per-episode token/cost accounting; one-command reproduce.
 

--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -43,8 +43,9 @@ a from-source coding harness that executes its own edits is well supported. Prio
 
 Each benchmark is one `BenchTask` (`setup` + `grade`); see `CONTRIBUTING.md`.
 
-- **[good first issue]** Lightweight, offline-gradable packs, one `BenchTask` each:
-  HumanEval, MBPP, BigCodeBench (lite), a LiveCodeBench subset.
+- **Shipped:** HumanEval and MBPP lightweight packs.
+- **[good first issue]** More lightweight, offline-gradable packs, one `BenchTask` each:
+  BigCodeBench (lite), a LiveCodeBench subset.
 - **[medium]** SWE-bench is already implemented (`proteus/bench/swe.py`) but heavy
   (x86_64 + large disk). Make it usable: wire **SWE-bench Lite / Verified** subsets, and
   degrade result-shape drift to a legible `0.0` instead of raising.

--- a/docs/BENCHMARKS.md
+++ b/docs/BENCHMARKS.md
@@ -38,6 +38,12 @@ proteus run --harness pi \
     --goal "Solve MBPP task 2 in task/solution.py." \
     --evaluator mbpp:2@observe \
     --arm neutral --seeds 2 --episodes 10 --out runs/mbpp-2
+
+# OpenAI HumanEval task; the official gzipped JSONL is downloaded and cached.
+proteus run --harness pi \
+    --goal "Solve HumanEval/0 in task/solution.py." \
+    --evaluator humaneval:HumanEval/0@observe \
+    --arm neutral --seeds 2 --episodes 10 --out runs/humaneval-0
 ```
 
 The CLI accepts at most one benchmark evaluator per run because a run has one task
@@ -62,6 +68,7 @@ to that `task/` directory.
 | built-in | `proteus.bench.local` | nothing | smoke tests, plumbing, CI |
 | **lightweight external** | `proteus.bench.polyglot` | Python + one shallow clone | real ablations at negligible cost |
 | **lightweight external** | `proteus.bench.mbpp` | Python + one cached JSON file | short, dense-scored synthesis tasks |
+| **lightweight external** | `proteus.bench.humaneval` | Python + one cached JSONL | official binary synthesis checks |
 | heavyweight official | `proteus.bench.swe` | Docker, ~120 GB, x86_64 | headline numbers on the real thing |
 
 **Start from `polyglot.py`** — it is deliberately the worked example. ~180 lines, no
@@ -74,6 +81,13 @@ MBPP uses Google Research's Apache-2.0 `sanitized-mbpp.json`. Set
 `PROTEUS_MBPP_PATH=/path/to/sanitized-mbpp.json` to use an existing copy; otherwise the
 file is cached under `~/.cache/proteus/mbpp/`. The prompt is seeded into the task, while
 the reference implementation and assertions remain held out by the grader.
+
+HumanEval uses OpenAI's MIT-licensed `HumanEval.jsonl.gz`. Set
+`PROTEUS_HUMANEVAL_PATH=/path/to/HumanEval.jsonl.gz` to use an existing copy; otherwise
+the file is cached under `~/.cache/proteus/humaneval/`. The public prompt is seeded into
+`solution.py`; the canonical solution and official `check(candidate)` function stay in
+the isolated grader. HumanEval's official per-sample verdict is binary, so its Proteus
+score is `0.0` or `1.0` rather than MBPP's per-assert fraction.
 
 ## What a contributed benchmark must get right
 

--- a/docs/superpowers/plans/2026-08-23-benchmark-reproducibility-isolation.md
+++ b/docs/superpowers/plans/2026-08-23-benchmark-reproducibility-isolation.md
@@ -1,0 +1,744 @@
+# Benchmark Reproducibility and Shared Isolation Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Pin and verify the official HumanEval/MBPP datasets, then replace their duplicated security-critical process harness with one shared isolation module without changing scoring behavior.
+
+**Architecture:** A focused `_datasets.py` owns verified atomic downloads while each benchmark retains its parser and user-supplied path policy. A focused `_isolation.py` owns the common value codec, named candidate worker, trusted remote-call proxy, and source binding; HumanEval and MBPP retain separate driver bodies for their distinct official-check and partial-score semantics.
+
+**Tech Stack:** Python 3.10+, stdlib (`hashlib`, `tempfile`, `urllib`, `subprocess`, `json`), pytest, Ruff.
+
+**Spec:** `docs/superpowers/specs/2026-08-23-benchmark-reproducibility-isolation-design.md`
+
+## Global Constraints
+
+- Preserve Python 3.10 support and the package's stdlib-only core dependency contract.
+- Preserve `dataset_path`, `list_tasks`, `humaneval_task`, and `mbpp_task` signatures.
+- Preserve HumanEval binary official-check scoring and driver-side prompt helpers.
+- Preserve MBPP per-assertion dense partial scoring.
+- Verify only automatic official downloads; explicit and environment-provided paths remain user-supplied and unverified.
+- Keep grading networkless and fail closed on missing, malformed, forged, timed-out, or nonzero worker reports.
+- Do not introduce a generic benchmark base class.
+
+---
+
+### Task 1: Immutable, Verified Official Dataset Downloads
+
+**Files:**
+- Create: `proteus/bench/_datasets.py`
+- Modify: `proteus/bench/humaneval.py:9-23,197-221`
+- Modify: `proteus/bench/mbpp.py:13-28,215-240`
+- Modify: `tests/test_humaneval.py:63-90`
+- Modify: `tests/test_mbpp.py:56-81`
+- Test: `tests/test_datasets.py`
+- Modify: `tests/run_offline.py:28-40`
+
+**Interfaces:**
+- Produces: `download_verified(*, name: str, url: str, expected_sha256: str, cache: Path, validate: Callable[[Path], object]) -> Path`.
+- Consumes: benchmark-local `_records(path)` functions as validation callbacks.
+- Produces constants:
+  - HumanEval URL commit `6d43fb980f9fee3c892a914eda09951f772ad10d` and SHA-256 `b796127e635a67f93fb35c04f4cb03cf06f38c8072ee7cee8833d7bee06979ef`.
+  - MBPP URL commit `e20eb00d074cdb569ee27318f112ea1e85bbb98f` and SHA-256 `ca95deaa9a01ef0a6f439f88bcf0dd3db3563d22f22aad6cae04ebb9a8d8c8e9`.
+
+- [ ] **Step 1: Add failing tests for the shared verified-download contract**
+
+Create `tests/test_datasets.py` with real byte payloads and a patched stdlib response:
+
+```python
+"""Verified official benchmark download behavior, fully offline."""
+
+import hashlib
+import io
+from unittest.mock import patch
+
+
+def test_verified_download_caches_only_a_matching_valid_payload(tmp_path):
+    from proteus.bench._datasets import download_verified
+
+    payload = b'[{"task_id": 1}]'
+    cache = tmp_path / "dataset.json"
+    validated = []
+
+    with patch("proteus.bench._datasets.request.urlopen", return_value=io.BytesIO(payload)) as get:
+        first = download_verified(
+            name="fixture",
+            url="https://example.invalid/pinned.json",
+            expected_sha256=hashlib.sha256(payload).hexdigest(),
+            cache=cache,
+            validate=lambda path: validated.append(path.read_bytes()),
+        )
+        second = download_verified(
+            name="fixture",
+            url="https://example.invalid/pinned.json",
+            expected_sha256=hashlib.sha256(payload).hexdigest(),
+            cache=cache,
+            validate=lambda path: validated.append(path.read_bytes()),
+        )
+
+    assert first == second == cache
+    assert cache.read_bytes() == payload
+    assert validated == [payload]
+    assert get.call_count == 1
+
+
+def test_verified_download_rejects_a_checksum_mismatch_without_publishing_cache(tmp_path):
+    from proteus.bench._datasets import download_verified
+
+    cache = tmp_path / "dataset.json"
+    with patch("proteus.bench._datasets.request.urlopen", return_value=io.BytesIO(b"changed")):
+        try:
+            download_verified(
+                name="fixture",
+                url="https://example.invalid/pinned.json",
+                expected_sha256="0" * 64,
+                cache=cache,
+                validate=lambda path: None,
+            )
+        except ValueError as exc:
+            assert "fixture checksum mismatch" in str(exc)
+            assert "expected" in str(exc) and "got" in str(exc)
+        else:
+            raise AssertionError("mismatched download was accepted")
+
+    assert not cache.exists()
+    assert list(tmp_path.iterdir()) == []
+
+
+def test_official_dataset_urls_and_hashes_are_immutable():
+    from proteus.bench import humaneval, mbpp
+
+    assert "6d43fb980f9fee3c892a914eda09951f772ad10d" in humaneval.DATA_URL
+    assert humaneval.DATA_SHA256 == "b796127e635a67f93fb35c04f4cb03cf06f38c8072ee7cee8833d7bee06979ef"
+    assert "e20eb00d074cdb569ee27318f112ea1e85bbb98f" in mbpp.DATA_URL
+    assert mbpp.DATA_SHA256 == "ca95deaa9a01ef0a6f439f88bcf0dd3db3563d22f22aad6cae04ebb9a8d8c8e9"
+    assert "/master/" not in humaneval.DATA_URL
+    assert "/master/" not in mbpp.DATA_URL
+```
+
+- [ ] **Step 2: Register the new test module in the no-pytest runner**
+
+Modify `tests/run_offline.py`:
+
+```python
+import test_datasets as D
+```
+
+and include `D` in the module tuple:
+
+```python
+for mod in (G, S, A, B, D, H, I, M, P, C):
+```
+
+- [ ] **Step 3: Run the new tests and verify RED**
+
+Run:
+
+```bash
+.venv/bin/pytest tests/test_datasets.py -q
+```
+
+Expected: FAIL because `proteus.bench._datasets` and `DATA_SHA256` do not exist.
+
+- [ ] **Step 4: Implement the minimal verified downloader**
+
+Create `proteus/bench/_datasets.py`:
+
+```python
+"""Verified, atomic downloads for official benchmark datasets."""
+
+from __future__ import annotations
+
+import hashlib
+import tempfile
+from pathlib import Path
+from typing import Callable
+from urllib import request
+
+
+def download_verified(*, name: str, url: str, expected_sha256: str, cache: Path,
+                      validate: Callable[[Path], object]) -> Path:
+    """Download one official dataset, verify bytes and format, then publish atomically."""
+    cache = Path(cache)
+    if cache.exists():
+        return cache
+    cache.parent.mkdir(parents=True, exist_ok=True)
+    with request.urlopen(url, timeout=30) as response:
+        payload = response.read()
+    actual = hashlib.sha256(payload).hexdigest()
+    if actual != expected_sha256:
+        raise ValueError(
+            f"{name} checksum mismatch: expected {expected_sha256}, got {actual}"
+        )
+    temporary = None
+    try:
+        with tempfile.NamedTemporaryFile(
+            dir=cache.parent, suffix="".join(cache.suffixes), delete=False
+        ) as stream:
+            stream.write(payload)
+            temporary = Path(stream.name)
+        validate(temporary)
+        temporary.replace(cache)
+    finally:
+        if temporary is not None:
+            temporary.unlink(missing_ok=True)
+    return cache
+```
+
+- [ ] **Step 5: Verify the shared downloader tests are GREEN**
+
+Run:
+
+```bash
+.venv/bin/pytest tests/test_datasets.py -q
+```
+
+Expected: the behavioral tests pass; the immutable-constant test still fails because the benchmark modules are not pinned yet.
+
+- [ ] **Step 6: Pin HumanEval and route only its automatic path through the helper**
+
+In `proteus/bench/humaneval.py`, replace the moving URL and local download block with:
+
+```python
+from proteus.bench._datasets import download_verified
+
+DATA_URL = (
+    "https://raw.githubusercontent.com/openai/human-eval/"
+    "6d43fb980f9fee3c892a914eda09951f772ad10d/data/HumanEval.jsonl.gz"
+)
+DATA_SHA256 = "b796127e635a67f93fb35c04f4cb03cf06f38c8072ee7cee8833d7bee06979ef"
+```
+
+The automatic branch becomes:
+
+```python
+cache = Path.home() / ".cache" / "proteus" / "humaneval" / "HumanEval.jsonl.gz"
+return download_verified(
+    name="HumanEval",
+    url=DATA_URL,
+    expected_sha256=DATA_SHA256,
+    cache=cache,
+    validate=_records,
+)
+```
+
+Remove now-unused `tempfile` and `urllib.request` imports. Keep the explicit argument and environment branches before this call so they bypass official checksum enforcement.
+
+- [ ] **Step 7: Pin MBPP and route only its automatic path through the helper**
+
+In `proteus/bench/mbpp.py`, use:
+
+```python
+from proteus.bench._datasets import download_verified
+
+DATA_URL = (
+    "https://raw.githubusercontent.com/google-research/google-research/"
+    "e20eb00d074cdb569ee27318f112ea1e85bbb98f/mbpp/sanitized-mbpp.json"
+)
+DATA_SHA256 = "ca95deaa9a01ef0a6f439f88bcf0dd3db3563d22f22aad6cae04ebb9a8d8c8e9"
+```
+
+The automatic branch becomes:
+
+```python
+cache = Path.home() / ".cache" / "proteus" / "mbpp" / "sanitized-mbpp.json"
+return download_verified(
+    name="MBPP",
+    url=DATA_URL,
+    expected_sha256=DATA_SHA256,
+    cache=cache,
+    validate=_records,
+)
+```
+
+Remove now-unused `tempfile` and `urllib.request` imports.
+
+- [ ] **Step 8: Update benchmark cache tests without allowing real network**
+
+In both existing `test_default_dataset_downloads_to_cache_once` tests, patch the shared
+request path and temporarily replace the production digest with the fixture digest:
+
+```python
+digest = hashlib.sha256(payload).hexdigest()
+with patch("proteus.bench.humaneval.DATA_SHA256", digest), patch(
+    "proteus.bench._datasets.request.urlopen", return_value=io.BytesIO(payload)
+) as get:
+    first = dataset_path()
+    second = dataset_path()
+```
+
+Use the corresponding `proteus.bench.mbpp.DATA_SHA256` patch for MBPP. Add explicit-path and
+environment-path tests that patch the module-local `download_verified` to raise if called,
+then assert the supplied fixture is returned. These prove the intentional bypass contract.
+
+Use this exact test shape in `tests/test_humaneval.py`, then repeat it with the MBPP fixture,
+environment variable, and module path in `tests/test_mbpp.py`:
+
+```python
+def test_user_supplied_dataset_paths_bypass_official_verification(tmp_path):
+    from unittest.mock import patch
+
+    from proteus.bench import humaneval
+
+    dataset, _ = _mini_dataset(tmp_path)
+    with patch.object(
+        humaneval, "download_verified", side_effect=AssertionError("official download called")
+    ):
+        assert humaneval.dataset_path(dataset) == dataset
+
+        old = os.environ.get("PROTEUS_HUMANEVAL_PATH")
+        os.environ["PROTEUS_HUMANEVAL_PATH"] = str(dataset)
+        try:
+            assert humaneval.dataset_path() == dataset
+        finally:
+            if old is None:
+                os.environ.pop("PROTEUS_HUMANEVAL_PATH", None)
+            else:
+                os.environ["PROTEUS_HUMANEVAL_PATH"] = old
+```
+
+- [ ] **Step 9: Run the dataset and benchmark tests**
+
+Run:
+
+```bash
+.venv/bin/pytest tests/test_datasets.py tests/test_humaneval.py tests/test_mbpp.py -q
+```
+
+Expected: all tests pass with no network access.
+
+- [ ] **Step 10: Run the offline runner and Ruff for this commit**
+
+Run:
+
+```bash
+.venv/bin/python tests/run_offline.py
+.venv/bin/ruff check proteus/bench/_datasets.py proteus/bench/humaneval.py proteus/bench/mbpp.py tests/test_datasets.py tests/test_humaneval.py tests/test_mbpp.py tests/run_offline.py
+git diff --check
+```
+
+Expected: zero failures and no lint or whitespace errors.
+
+- [ ] **Step 11: Commit the dataset change**
+
+```bash
+git add proteus/bench/_datasets.py proteus/bench/humaneval.py proteus/bench/mbpp.py \
+  tests/test_datasets.py tests/test_humaneval.py tests/test_mbpp.py tests/run_offline.py
+git commit -m "fix: pin and verify benchmark datasets"
+```
+
+---
+
+### Task 2: Shared Parent/Worker Isolation Harness
+
+**Files:**
+- Create: `proteus/bench/_isolation.py`
+- Modify: `proteus/bench/humaneval.py:27-194,257-290`
+- Modify: `proteus/bench/mbpp.py:32-212,279-327`
+- Create: `tests/test_benchmark_isolation.py`
+- Modify: `tests/test_humaneval.py:109-126`
+- Modify: `tests/test_mbpp.py:156-259`
+- Modify: `tests/run_offline.py:28-40`
+
+**Interfaces:**
+- Produces: `build_worker_source(worker_prefix: str) -> str`.
+- Produces: `build_driver_source(*, report_prefix: str, worker_prefix: str, call_timeout_s: int, bindings: Mapping[str, object], body: str) -> str`.
+- The shared worker request schema is `{"name": str, "args": encoded, "kwargs": encoded}`.
+- HumanEval supplies `ENTRY_POINT` to `_RemoteFunction(ENTRY_POINT)` in its private body.
+- MBPP supplies each value in `ENTRY_POINTS` to `_RemoteFunction(name)` in its private body.
+
+- [ ] **Step 1: Add the failing shared-module contract test**
+
+Create `tests/test_benchmark_isolation.py` beginning with:
+
+```python
+"""One adversarial contract for every benchmark using the shared process harness."""
+
+
+def test_shared_isolation_builds_a_named_worker_and_bound_driver():
+    from proteus.bench._isolation import build_driver_source, build_worker_source
+
+    worker = build_worker_source("VALUE:random:")
+    driver = build_driver_source(
+        report_prefix="RESULT:random:",
+        worker_prefix="VALUE:random:",
+        call_timeout_s=7,
+        bindings={"ENTRY_POINT": "clamp"},
+        body="candidate = _RemoteFunction(ENTRY_POINT)\n",
+    )
+
+    compile(worker, "<worker>", "exec")
+    compile(driver, "<driver>", "exec")
+    assert 'request["name"]' in worker
+    assert "WORKER_SOURCE" in driver
+    assert "CALL_TIMEOUT_S = 7" in driver
+    assert "ENTRY_POINT = 'clamp'" in driver
+```
+
+- [ ] **Step 2: Add one cross-benchmark adversarial suite before refactoring**
+
+In the same file, create `_targets(tmp_path)` from the existing fabricated HumanEval and
+MBPP fixtures. Each yielded value is `(name, task, workspace)` with its own directory. Add
+plain test functions that loop over both targets and assert score zero for these candidate
+actions:
+
+```python
+ATTACKS = {
+    "patch-builtins": "import builtins\nbuiltins.exec = lambda *a, **k: None\n",
+    "early-exit": "import os\nos._exit(0)\n",
+    "late-report": (
+        "import atexit\n"
+        "atexit.register(lambda: print('PROTEUS_FAKE_RESULT:pass'))\n"
+    ),
+    "frame-search": (
+        "import os, sys\n"
+        "frame = sys._getframe()\n"
+        "while frame is not None:\n"
+        "    scope = frame.f_globals\n"
+        "    if 'REPORT_PREFIX' in scope:\n"
+        "        print(scope['REPORT_PREFIX'] + 'pass', flush=True)\n"
+        "        os._exit(0)\n"
+        "    frame = frame.f_back\n"
+    ),
+}
+```
+
+Use concrete target construction rather than a pytest parametrization so the no-pytest runner
+can execute the same suite:
+
+```python
+def _targets(tmp_path):
+    from test_humaneval import _seed_task as seed_humaneval
+    from test_mbpp import _seed_task as seed_mbpp
+
+    human = tmp_path / "humaneval"
+    mbpp = tmp_path / "mbpp"
+    human.mkdir(parents=True)
+    mbpp.mkdir(parents=True)
+    human_task, human_ws, _ = seed_humaneval(human)
+    mbpp_task, mbpp_ws, _ = seed_mbpp(mbpp)
+    return (("humaneval", human_task, human_ws), ("mbpp", mbpp_task, mbpp_ws))
+
+
+def test_candidate_attacks_cannot_reach_or_forge_trusted_control(tmp_path, trusted_grader):
+    for attack, source in ATTACKS.items():
+        for name, task, ws in _targets(tmp_path / attack):
+            (ws / "solution.py").write_text(source, encoding="utf-8")
+            result = task.grade(ws, sandbox=trusted_grader)
+            assert result.score == 0.0 and not result.passed, (attack, name, result)
+
+
+def test_candidate_cannot_replace_the_driver_file(tmp_path, trusted_grader):
+    for name, task, ws in _targets(tmp_path):
+        (ws / "_grade.py").write_text("print('forged pass')\n", encoding="utf-8")
+        result = task.grade(ws, sandbox=trusted_grader)
+        assert result.score == 0.0 and not result.passed, (name, result)
+        assert not (ws / "_grade.py").exists()
+```
+
+Add the task-local shadow attempt with the same frame-search body currently used by MBPP:
+
+```python
+def test_task_local_module_cannot_shadow_trusted_driver_imports(tmp_path, trusted_grader):
+    malicious = (
+        "import os, sys\n"
+        "frame = sys._getframe()\n"
+        "while frame is not None:\n"
+        "    scope = frame.f_globals\n"
+        "    if 'REPORT_PREFIX' in scope:\n"
+        "        print(scope['REPORT_PREFIX'] + 'pass', flush=True)\n"
+        "        os._exit(0)\n"
+        "    frame = frame.f_back\n"
+        "raise ImportError('trusted driver not found')\n"
+    )
+    for name, task, ws in _targets(tmp_path):
+        (ws / "base64.py").write_text(malicious, encoding="utf-8")
+        result = task.grade(ws, sandbox=trusted_grader)
+        assert result.score == 0.0 and not result.passed, (name, result)
+```
+
+Finally add shared malformed-stream cases:
+
+```python
+def test_malformed_or_none_grader_streams_fail_closed(tmp_path):
+    import subprocess
+
+    class BrokenSandbox:
+        def __init__(self, stdout, stderr):
+            self.stdout, self.stderr = stdout, stderr
+
+        def run(self, *args, **kwargs):
+            return subprocess.CompletedProcess(
+                ["python", "_grade.py"], 0, self.stdout, self.stderr
+            )
+
+    for case, streams in (("noise", ("noise\n", "")), ("none", (None, None))):
+        for name, task, ws in _targets(tmp_path / case):
+            result = task.grade(ws, sandbox=BrokenSandbox(*streams))
+            assert result.score == 0.0 and not result.passed, (case, name, result)
+            assert "no report" in result.detail
+```
+
+- [ ] **Step 3: Register the shared adversarial module in the offline runner**
+
+Modify `tests/run_offline.py`:
+
+```python
+import test_benchmark_isolation as Q
+```
+
+and include `Q` once in the test-module tuple.
+
+- [ ] **Step 4: Run the shared module test and verify RED**
+
+Run:
+
+```bash
+.venv/bin/pytest tests/test_benchmark_isolation.py::test_shared_isolation_builds_a_named_worker_and_bound_driver -q
+```
+
+Expected: FAIL because `proteus.bench._isolation` does not exist.
+
+- [ ] **Step 5: Implement the shared isolation source builders**
+
+Create `proteus/bench/_isolation.py` with the existing codec moved verbatim once, followed by
+a generic named worker and driver support. The public construction surface is:
+
+```python
+from __future__ import annotations
+
+from typing import Mapping
+
+
+def build_worker_source(worker_prefix: str) -> str:
+    """Return a self-contained candidate worker with a private result prefix."""
+    return f"WORKER_PREFIX = {worker_prefix!r}\n" + WORKER_SOURCE
+
+
+def build_driver_source(*, report_prefix: str, worker_prefix: str,
+                        call_timeout_s: int, bindings: Mapping[str, object],
+                        body: str) -> str:
+    """Bind trusted values around the common remote-call support and benchmark body."""
+    worker = build_worker_source(worker_prefix)
+    values = {
+        **dict(bindings),
+        "REPORT_PREFIX": report_prefix,
+        "WORKER_PREFIX": worker_prefix,
+        "WORKER_SOURCE": worker,
+        "CALL_TIMEOUT_S": call_timeout_s,
+    }
+    header = "".join(f"{name} = {value!r}\n" for name, value in values.items())
+    return header + DRIVER_SUPPORT_SOURCE + body
+```
+
+The shared worker must use the normalized request name:
+
+```python
+request = json_loads(sys.argv[1])
+source = solution.read_text(encoding="utf-8")
+trusted_exec(trusted_compile(source, str(solution), "exec"), namespace)
+function = namespace[request["name"]]
+value = function(*_decode(request["args"]), **_decode(request["kwargs"]))
+```
+
+The shared driver proxy must send that name and fail explicitly when no private worker report
+exists:
+
+```python
+class _RemoteFunction:
+    def __init__(self, name):
+        self.name = name
+
+    def __call__(self, *args, **kwargs):
+        return _remote_call(self.name, args, kwargs)
+```
+
+- [ ] **Step 6: Verify the shared source-builder test is GREEN**
+
+Run:
+
+```bash
+.venv/bin/pytest tests/test_benchmark_isolation.py::test_shared_isolation_builds_a_named_worker_and_bound_driver -q
+```
+
+Expected: PASS.
+
+- [ ] **Step 7: Migrate HumanEval while retaining its private official-check body**
+
+Replace HumanEval's `_CODEC`, `_WORKER`, and common `_DRIVER` support with imports:
+
+```python
+from proteus.bench._isolation import build_driver_source
+```
+
+Keep a HumanEval-only `_DRIVER_BODY`:
+
+```python
+_DRIVER_BODY = '''\
+try:
+    Path(__file__).resolve().unlink()
+    namespace = {"__name__": "__main__"}
+    exec(PROMPT_SOURCE, namespace)
+    candidate = _RemoteFunction(ENTRY_POINT)
+    namespace[ENTRY_POINT] = candidate
+    exec(TEST_SOURCE, namespace)
+    namespace["check"](candidate)
+    passed = True
+except caught:
+    passed = False
+emit(REPORT_PREFIX + ("pass" if passed else "fail") + "\\n")
+flush()
+exit_now(0)
+'''
+```
+
+Build `_grade.py` with:
+
+```python
+driver.write_text(
+    build_driver_source(
+        report_prefix=report_prefix,
+        worker_prefix=worker_prefix,
+        call_timeout_s=CALL_TIMEOUT_S,
+        bindings={
+            "PROMPT_SOURCE": spec["prompt"],
+            "TEST_SOURCE": spec["test"],
+            "ENTRY_POINT": spec["entry_point"],
+        },
+        body=_DRIVER_BODY,
+    ),
+    encoding="utf-8",
+)
+```
+
+- [ ] **Step 8: Run HumanEval correctness and shared adversarial tests**
+
+Run:
+
+```bash
+.venv/bin/pytest tests/test_humaneval.py tests/test_benchmark_isolation.py -q
+```
+
+Expected: HumanEval's stub still fails, canonical solution and prompt helper pass, and all
+shared HumanEval attack cases fail closed.
+
+- [ ] **Step 9: Migrate MBPP while retaining its private partial-score body**
+
+Replace MBPP's duplicate codec/worker/driver support with `build_driver_source`. Keep its
+existing trusted import, proxy installation, assertion loop, and `_report(passed)` logic in
+an MBPP-only `_DRIVER_BODY`. Bind `TESTS`, `TEST_IMPORTS`, `REFERENCE_IMPORTS`, and
+`ENTRY_POINTS` through the `bindings` mapping.
+
+The complete benchmark-owned body is the current assertion loop without the shared imports
+and proxy definition:
+
+```python
+_DRIVER_BODY = '''\
+def _report(passed):
+    emit(REPORT_PREFIX + str(passed) + "/" + str(len(TESTS)) + "\\n")
+    flush()
+    exit_now(0)
+
+try:
+    Path(__file__).resolve().unlink()
+except OSError:
+    _report(0)
+
+namespace = {"__name__": "__main__"}
+try:
+    for statement in TEST_IMPORTS + REFERENCE_IMPORTS:
+        exec(statement, namespace)
+    for name in ENTRY_POINTS:
+        namespace[name] = _RemoteFunction(name)
+except caught:
+    _report(0)
+
+passed = 0
+for assertion in TESTS:
+    try:
+        exec(assertion, namespace)
+        passed += 1
+    except caught:
+        pass
+_report(passed)
+'''
+```
+
+Replace `_driver` with:
+
+```python
+def _driver(spec: dict, report_prefix: str, worker_prefix: str) -> str:
+    return build_driver_source(
+        report_prefix=report_prefix,
+        worker_prefix=worker_prefix,
+        call_timeout_s=CALL_TIMEOUT_S,
+        bindings={
+            "TEST_IMPORTS": list(spec.get("test_imports", [])),
+            "REFERENCE_IMPORTS": _reference_imports(spec),
+            "TESTS": list(spec["test_list"]),
+            "ENTRY_POINTS": _entry_points(spec),
+        },
+        body=_DRIVER_BODY,
+    )
+```
+
+The candidate worker now always receives the common `{name, args, kwargs}` request, which is
+the schema MBPP already uses.
+
+- [ ] **Step 10: Run both benchmark suites before removing duplicate attack tests**
+
+Run:
+
+```bash
+.venv/bin/pytest tests/test_humaneval.py tests/test_mbpp.py tests/test_benchmark_isolation.py -q
+```
+
+Expected: all old benchmark tests and all new shared tests pass.
+
+- [ ] **Step 11: Consolidate the adversarial tests into the shared suite**
+
+Remove only the cases now exercised for both packs from their old locations:
+
+- HumanEval: `test_candidate_cannot_reach_trusted_control_through_frames`.
+- MBPP: grader replacement, patched `exec`, frame traversal, module shadowing, forged late
+  report, early exit, malformed report, and `None` streams.
+
+Keep benchmark-specific functional, partial-score, import, opaque-value, unavailable-sandbox,
+and CLI tests in their original modules. Re-run the same three test files after removal to
+prove consolidation did not reduce the contract.
+
+- [ ] **Step 12: Run the complete verification gate**
+
+Run:
+
+```bash
+.venv/bin/pytest -q
+.venv/bin/python tests/run_offline.py
+.venv/bin/ruff check .
+git diff --check
+```
+
+Expected: all pytest and offline tests pass, the one opt-in conformance test may remain
+skipped, Ruff reports no findings, and Git reports no whitespace errors.
+
+- [ ] **Step 13: Inspect the duplication removal and working-tree scope**
+
+Run:
+
+```bash
+rg -n '^_CODEC|^_WORKER|^_DRIVER' proteus/bench/humaneval.py proteus/bench/mbpp.py proteus/bench/_isolation.py
+git status --short
+git diff --stat HEAD~1
+```
+
+Expected: the common codec/worker/driver support appears only in `_isolation.py`; benchmark
+modules retain only `_DRIVER_BODY`; changed files are limited to this plan's production,
+test, and documentation scope.
+
+- [ ] **Step 14: Commit the shared-isolation change**
+
+```bash
+git add proteus/bench/_isolation.py proteus/bench/humaneval.py proteus/bench/mbpp.py \
+  tests/test_benchmark_isolation.py tests/test_humaneval.py tests/test_mbpp.py \
+  tests/run_offline.py
+git commit -m "refactor: share benchmark isolation harness"
+```

--- a/docs/superpowers/specs/2026-08-23-benchmark-reproducibility-isolation-design.md
+++ b/docs/superpowers/specs/2026-08-23-benchmark-reproducibility-isolation-design.md
@@ -1,0 +1,134 @@
+# Benchmark Reproducibility and Shared Isolation Design
+
+## Context
+
+The HumanEval benchmark added in PR #16 reuses the parent/worker isolation shape from
+MBPP. The design keeps held-out tests and prompt helpers in a trusted driver while each
+candidate function executes in a separate worker process. Review found no blocking defect,
+but identified two follow-ups before more benchmark packs are added:
+
+1. automatic dataset downloads use moving `master` URLs without integrity verification;
+2. the security-critical codec, worker transport, and driver proxy are substantially
+   duplicated between HumanEval and MBPP.
+
+This change fixes both without changing benchmark scoring semantics or expanding the public
+API.
+
+## Goals
+
+- Make official HumanEval and MBPP downloads byte-for-byte reproducible.
+- Reject corrupted or unexpectedly changed official downloads before they enter the cache.
+- Keep explicit paths and `PROTEUS_HUMANEVAL_PATH` / `PROTEUS_MBPP_PATH` available for
+  user-supplied datasets without imposing the official checksum.
+- Give HumanEval and MBPP one shared implementation of value encoding, candidate worker
+  execution, remote calls, random report channels, and failure handling.
+- Preserve HumanEval's official `check(candidate)` behavior, including driver-side prompt
+  helpers.
+- Preserve MBPP's per-assertion partial scoring.
+- Run the adversarial isolation contract against both benchmark packs.
+
+## Non-goals
+
+- No generic benchmark base class or plugin framework.
+- No change to `BenchTask`, CLI flags, task IDs, cache locations, or evaluator result shape.
+- No checksum enforcement for explicit or environment-provided dataset paths.
+- No network fallback during grading.
+- No attempt to make Python process isolation replace the existing networkless Docker
+  grader; the shared harness remains defense in depth inside that container.
+
+## Dataset Reproducibility
+
+Each benchmark module will declare an official immutable raw URL containing a full upstream
+commit SHA and a SHA-256 digest for the downloaded bytes. Automatic download follows this
+sequence:
+
+1. fetch bytes from the immutable URL;
+2. compare `sha256(payload)` with the module's expected digest;
+3. parse and validate the dataset using the benchmark's existing loader;
+4. atomically replace the cache path only after both checks pass.
+
+A checksum mismatch raises `ValueError` with the benchmark name, expected digest, and actual
+digest. No cache file is published. An existing cache retains the current behavior: it is
+used without a network request. Explicit function arguments and environment paths bypass
+the official downloader and are parsed normally; they are intentionally user-controlled.
+
+The small download primitive will live in `proteus/bench/_datasets.py` so both packs share
+the ordering and failure semantics. It accepts the URL, expected digest, cache path, and a
+validation callable; benchmark-specific parsing stays in the benchmark module.
+
+## Shared Isolation Boundary
+
+`proteus/bench/_isolation.py` will own only mechanics that are identical across benchmark
+packs:
+
+- the value codec source used on both sides of the process boundary;
+- a candidate worker source that loads `solution.py`, selects a named entry point, executes
+  one call, and emits one randomly-prefixed encoded response;
+- the trusted driver support source that launches workers, validates their exit/report,
+  decodes values, and exposes a named remote-function proxy;
+- construction helpers that bind random prefixes, worker source, and call timeout into a
+  self-contained grader script.
+
+The request schema is normalized to `{name, args, kwargs}`. HumanEval supplies its single
+official entry-point name on every call; MBPP continues to supply the function referenced by
+each assertion. This removes the only material worker protocol difference.
+
+Benchmark-owned driver bodies remain separate:
+
+- HumanEval executes `PROMPT_SOURCE` in the trusted driver, replaces only the official entry
+  point with the remote proxy, executes held-out `TEST_SOURCE`, and calls `check(candidate)`.
+- MBPP installs remote proxies for every declared entry point, executes trusted imports and
+  assertions, and reports the number passed.
+
+Candidate code never receives prompt tests, reference imports, report prefixes, or driver
+frames. Candidate stdout is not itself a grade; only the trusted driver emits the final
+randomly-prefixed report consumed by the host evaluator.
+
+## Failure Semantics
+
+- A worker timeout, nonzero exit, malformed response, missing random-prefix report, or
+  candidate exception becomes a failed candidate call.
+- HumanEval maps any official check failure to score `0.0`; a complete official check maps
+  to `1.0`.
+- MBPP maps each failed assertion to zero credit for that assertion and preserves dense
+  partial scoring for the remainder.
+- A grader timeout or unavailable Docker sandbox retains the existing scored-failure
+  behavior.
+- The temporary `_grade.py` is deleted in all outcomes.
+
+## Tests
+
+Development follows red-green-refactor.
+
+Dataset tests will prove:
+
+- automatic downloads use immutable commit URLs;
+- matching payloads validate, cache atomically, and are reused without another request;
+- checksum mismatches raise and leave no cache file;
+- explicit and environment paths bypass the official checksum while remaining parseable.
+
+Isolation tests will be parameterized across HumanEval and MBPP where the attack applies:
+
+- candidate attempts to forge a final grader report;
+- candidate exits the worker early;
+- candidate patches `builtins`, including `exec`;
+- task-local modules attempt to shadow trusted grader imports;
+- candidate attempts to reach trusted control data through stack frames;
+- malformed or missing worker reports fail closed.
+
+Existing benchmark-specific correctness tests remain: canonical solutions pass, seeded
+stubs fail, HumanEval prompt helpers execute in the trusted driver, and MBPP partial scores
+remain dense.
+
+The final gate is the complete pytest suite, `tests/run_offline.py`, and Ruff. No live model,
+Docker image download, or external network is required by the new tests.
+
+## Compatibility and Rollout
+
+The refactor preserves the public functions `dataset_path`, `list_tasks`, and task factory
+signatures. Existing cache paths remain valid. Previously cached files are not retroactively
+hashed because they may predate the pin and users may deliberately manage those caches; a
+fresh automatic download is the integrity boundary introduced here.
+
+The two changes will be implemented as independently testable commits: dataset pinning and
+verification first, shared isolation second. This keeps review and rollback straightforward.

--- a/proteus/bench/_datasets.py
+++ b/proteus/bench/_datasets.py
@@ -1,0 +1,39 @@
+"""Verified, atomic downloads for official benchmark datasets."""
+
+from __future__ import annotations
+
+import hashlib
+import tempfile
+from pathlib import Path
+from typing import Callable
+from urllib import request
+
+
+def download_verified(
+    *, name: str, url: str, expected_sha256: str, cache: Path, validate: Callable[[Path], object]
+) -> Path:
+    """Download one official dataset, verify bytes and format, then publish atomically."""
+    cache = Path(cache)
+    if cache.exists():
+        return cache
+    cache.parent.mkdir(parents=True, exist_ok=True)
+    with request.urlopen(url, timeout=30) as response:
+        payload = response.read()
+    actual = hashlib.sha256(payload).hexdigest()
+    if actual != expected_sha256:
+        raise ValueError(
+            f"{name} checksum mismatch: expected {expected_sha256}, got {actual}"
+        )
+    temporary = None
+    try:
+        with tempfile.NamedTemporaryFile(
+            dir=cache.parent, suffix="".join(cache.suffixes), delete=False
+        ) as stream:
+            stream.write(payload)
+            temporary = Path(stream.name)
+        validate(temporary)
+        temporary.replace(cache)
+    finally:
+        if temporary is not None:
+            temporary.unlink(missing_ok=True)
+    return cache

--- a/proteus/bench/_isolation.py
+++ b/proteus/bench/_isolation.py
@@ -1,0 +1,190 @@
+"""Shared source builders for benchmark parent/worker process isolation."""
+
+from __future__ import annotations
+
+from typing import Mapping
+
+
+_CODEC = '''\
+import base64
+
+_type = type
+_isinstance = isinstance
+_bool = bool
+_int = int
+_float = float
+_complex = complex
+_str = str
+_bytes = bytes
+_list = list
+_tuple = tuple
+_set = set
+_frozenset = frozenset
+_dict = dict
+
+class _OpaqueValue:
+    def __init__(self, truthy):
+        self.truthy = truthy
+
+    def __bool__(self):
+        return self.truthy
+
+def _encode(value):
+    kind = _type(value)
+    if value is None:
+        return {"type": "none"}
+    if kind is _bool:
+        return {"type": "bool", "value": value}
+    if kind is _int:
+        return {"type": "int", "value": _str(value)}
+    if kind is _float:
+        return {"type": "float", "value": _str(value)}
+    if kind is _complex:
+        return {"type": "complex", "real": _str(value.real), "imag": _str(value.imag)}
+    if kind is _str:
+        return {"type": "str", "value": value}
+    if kind is _bytes:
+        return {"type": "bytes", "value": base64.b64encode(value).decode("ascii")}
+    if _isinstance(value, _list):
+        return {"type": "list", "items": [_encode(item) for item in value]}
+    if _isinstance(value, _tuple):
+        return {"type": "tuple", "items": [_encode(item) for item in value]}
+    if _isinstance(value, (_set, _frozenset)):
+        return {"type": "set", "items": [_encode(item) for item in value]}
+    if _isinstance(value, _dict):
+        return {"type": "dict", "items": [[_encode(k), _encode(v)] for k, v in value.items()]}
+    return {"type": "opaque", "truthy": _bool(value)}
+
+def _decode(node):
+    kind = node["type"]
+    if kind == "none":
+        return None
+    if kind == "bool":
+        return _bool(node["value"])
+    if kind == "int":
+        return _int(node["value"])
+    if kind == "float":
+        return _float(node["value"])
+    if kind == "complex":
+        return _complex(_float(node["real"]), _float(node["imag"]))
+    if kind == "str":
+        return _str(node["value"])
+    if kind == "bytes":
+        return base64.b64decode(node["value"], validate=True)
+    if kind == "list":
+        return [_decode(item) for item in node["items"]]
+    if kind == "tuple":
+        return _tuple(_decode(item) for item in node["items"])
+    if kind == "set":
+        return {_decode(item) for item in node["items"]}
+    if kind == "dict":
+        return {_decode(k): _decode(v) for k, v in node["items"]}
+    if kind == "opaque":
+        return _OpaqueValue(_bool(node["truthy"]))
+    raise ValueError(f"unknown isolated value type: {kind!r}")
+'''
+
+WORKER_SOURCE = _CODEC + '''\
+import builtins
+import json
+import os
+import sys
+from pathlib import Path
+
+trusted_exec = exec
+trusted_compile = compile
+caught = BaseException
+json_loads = json.loads
+json_dumps = json.dumps
+emit = sys.stdout.write
+flush = sys.stdout.flush
+exit_now = os._exit
+here = Path.cwd()
+solution = here / "solution.py"
+namespace = {"__name__": "__main__", "__file__": str(solution),
+             "__builtins__": dict(vars(builtins))}
+try:
+    request = json_loads(sys.argv[1])
+    source = solution.read_text(encoding="utf-8")
+    trusted_exec(trusted_compile(source, str(solution), "exec"), namespace)
+    function = namespace[request["name"]]
+    value = function(*_decode(request["args"]), **_decode(request["kwargs"]))
+    response = {"ok": True, "value": _encode(value)}
+except caught as exc:
+    response = {"ok": False, "error": f"{_type(exc).__name__}: {exc}"}
+emit(WORKER_PREFIX + json_dumps(response, separators=(",", ":")) + "\\n")
+flush()
+exit_now(0)
+'''
+
+DRIVER_SUPPORT_SOURCE = _CODEC + '''\
+import json
+import os
+import subprocess
+import sys
+from pathlib import Path
+
+caught = BaseException
+emit = sys.stdout.write
+flush = sys.stdout.flush
+exit_now = os._exit
+here = Path(__file__).resolve().parent
+
+def _remote_call(name, args, kwargs):
+    request = json.dumps(
+        {"name": name, "args": _encode(args), "kwargs": _encode(kwargs)},
+        separators=(",", ":"),
+    )
+    proc = subprocess.run(
+        [sys.executable, "-c", WORKER_SOURCE, request],
+        cwd=here,
+        stdin=subprocess.DEVNULL,
+        capture_output=True,
+        text=True,
+        timeout=CALL_TIMEOUT_S,
+        check=False,
+    )
+    if proc.returncode != 0:
+        raise RuntimeError("candidate worker failed")
+    reports = [line for line in proc.stdout.splitlines() if line.startswith(WORKER_PREFIX)]
+    if not reports:
+        raise RuntimeError("candidate worker produced no report")
+    response = json.loads(reports[-1][len(WORKER_PREFIX):])
+    if not response.get("ok"):
+        raise RuntimeError(response.get("error", "candidate call failed"))
+    return _decode(response["value"])
+
+class _RemoteFunction:
+    def __init__(self, name):
+        self.name = name
+
+    def __call__(self, *args, **kwargs):
+        return _remote_call(self.name, args, kwargs)
+
+'''
+
+
+def build_worker_source(worker_prefix: str) -> str:
+    """Return a self-contained candidate worker with a private result prefix."""
+    return f"WORKER_PREFIX = {worker_prefix!r}\n" + WORKER_SOURCE
+
+
+def build_driver_source(
+    *,
+    report_prefix: str,
+    worker_prefix: str,
+    call_timeout_s: int,
+    bindings: Mapping[str, object],
+    body: str,
+) -> str:
+    """Bind trusted values around the common remote-call support and benchmark body."""
+    worker = build_worker_source(worker_prefix)
+    values = {
+        **dict(bindings),
+        "REPORT_PREFIX": report_prefix,
+        "WORKER_PREFIX": worker_prefix,
+        "WORKER_SOURCE": worker,
+        "CALL_TIMEOUT_S": call_timeout_s,
+    }
+    header = "".join(f"{name} = {value!r}\n" for name, value in values.items())
+    return header + DRIVER_SUPPORT_SOURCE + body

--- a/proteus/bench/_isolation.py
+++ b/proteus/bench/_isolation.py
@@ -84,7 +84,9 @@ def _decode(node):
     raise ValueError(f"unknown isolated value type: {kind!r}")
 '''
 
-WORKER_SOURCE = _CODEC + '''\
+EXECUTOR_PREFIX = "PROTEUS_CANDIDATE_RESULT:"
+
+EXECUTOR_SOURCE = _CODEC + '''\
 import builtins
 import json
 import os
@@ -112,6 +114,51 @@ try:
     response = {"ok": True, "value": _encode(value)}
 except caught as exc:
     response = {"ok": False, "error": f"{_type(exc).__name__}: {exc}"}
+emit(EXECUTOR_PREFIX + json_dumps(response, separators=(",", ":")) + "\\n")
+flush()
+exit_now(0)
+'''
+
+WORKER_SOURCE = _CODEC + '''\
+import json
+import os
+import subprocess
+import sys
+from pathlib import Path
+
+caught = BaseException
+json_loads = json.loads
+json_dumps = json.dumps
+emit = sys.stdout.write
+flush = sys.stdout.flush
+exit_now = os._exit
+here = Path.cwd()
+try:
+    proc = subprocess.run(
+        [sys.executable, "-c", EXECUTOR_SOURCE, sys.argv[1]],
+        cwd=here,
+        stdin=subprocess.DEVNULL,
+        capture_output=True,
+        text=True,
+        timeout=float(sys.argv[2]),
+        check=False,
+    )
+    if proc.returncode != 0:
+        raise RuntimeError("candidate executor failed")
+    reports = [
+        line for line in proc.stdout.splitlines() if line.startswith(EXECUTOR_PREFIX)
+    ]
+    if not reports:
+        raise RuntimeError("candidate executor produced no result")
+    candidate_response = json_loads(reports[-1][len(EXECUTOR_PREFIX):])
+    if candidate_response.get("ok"):
+        response = {"ok": True, "value": _encode(_decode(candidate_response["value"]))}
+    else:
+        response = {"ok": False, "error": candidate_response.get(
+            "error", "candidate call failed"
+        )}
+except caught as exc:
+    response = {"ok": False, "error": f"{_type(exc).__name__}: {exc}"}
 emit(WORKER_PREFIX + json_dumps(response, separators=(",", ":")) + "\\n")
 flush()
 exit_now(0)
@@ -136,7 +183,7 @@ def _remote_call(name, args, kwargs):
         separators=(",", ":"),
     )
     proc = subprocess.run(
-        [sys.executable, "-c", WORKER_SOURCE, request],
+        [sys.executable, "-I", "-c", WORKER_SOURCE, request, str(CALL_TIMEOUT_S)],
         cwd=here,
         stdin=subprocess.DEVNULL,
         capture_output=True,
@@ -166,7 +213,13 @@ class _RemoteFunction:
 
 def build_worker_source(worker_prefix: str) -> str:
     """Return a self-contained candidate worker with a private result prefix."""
-    return f"WORKER_PREFIX = {worker_prefix!r}\n" + WORKER_SOURCE
+    executor = f"EXECUTOR_PREFIX = {EXECUTOR_PREFIX!r}\n" + EXECUTOR_SOURCE
+    return (
+        f"WORKER_PREFIX = {worker_prefix!r}\n"
+        f"EXECUTOR_PREFIX = {EXECUTOR_PREFIX!r}\n"
+        f"EXECUTOR_SOURCE = {executor!r}\n"
+        + WORKER_SOURCE
+    )
 
 
 def build_driver_source(

--- a/proteus/bench/_isolation.py
+++ b/proteus/bench/_isolation.py
@@ -2,6 +2,8 @@
 
 from __future__ import annotations
 
+import os
+from pathlib import Path
 from typing import Mapping
 
 
@@ -84,8 +86,6 @@ def _decode(node):
     raise ValueError(f"unknown isolated value type: {kind!r}")
 '''
 
-EXECUTOR_PREFIX = "PROTEUS_CANDIDATE_RESULT:"
-
 EXECUTOR_SOURCE = _CODEC + '''\
 import builtins
 import json
@@ -98,11 +98,12 @@ trusted_compile = compile
 caught = BaseException
 json_loads = json.loads
 json_dumps = json.dumps
-emit = sys.stdout.write
-flush = sys.stdout.flush
+write_result = os.write
+close_result = os.close
 exit_now = os._exit
 here = Path.cwd()
 solution = here / "solution.py"
+result_fd = int(sys.argv[2])
 namespace = {"__name__": "__main__", "__file__": str(solution),
              "__builtins__": dict(vars(builtins))}
 try:
@@ -114,16 +115,20 @@ try:
     response = {"ok": True, "value": _encode(value)}
 except caught as exc:
     response = {"ok": False, "error": f"{_type(exc).__name__}: {exc}"}
-emit(EXECUTOR_PREFIX + json_dumps(response, separators=(",", ":")) + "\\n")
-flush()
+payload = json_dumps(response, separators=(",", ":")).encode("utf-8")
+while payload:
+    payload = payload[write_result(result_fd, payload):]
+close_result(result_fd)
 exit_now(0)
 '''
 
 WORKER_SOURCE = _CODEC + '''\
 import json
 import os
+import signal
 import subprocess
 import sys
+import tempfile
 from pathlib import Path
 
 caught = BaseException
@@ -133,24 +138,39 @@ emit = sys.stdout.write
 flush = sys.stdout.flush
 exit_now = os._exit
 here = Path.cwd()
+
+def _terminate_process_group(proc):
+    try:
+        os.killpg(proc.pid, signal.SIGKILL)
+    except ProcessLookupError:
+        pass
+    return proc.communicate()
+
 try:
-    proc = subprocess.run(
-        [sys.executable, "-c", EXECUTOR_SOURCE, sys.argv[1]],
-        cwd=here,
-        stdin=subprocess.DEVNULL,
-        capture_output=True,
-        text=True,
-        timeout=float(sys.argv[2]),
-        check=False,
-    )
+    with tempfile.TemporaryFile() as result_stream:
+        proc = subprocess.Popen(
+            [sys.executable, "-c", EXECUTOR_SOURCE, sys.argv[1],
+             str(result_stream.fileno())],
+            cwd=here,
+            stdin=subprocess.DEVNULL,
+            stdout=subprocess.PIPE,
+            stderr=subprocess.PIPE,
+            text=True,
+            pass_fds=(result_stream.fileno(),),
+            start_new_session=True,
+        )
+        try:
+            proc.communicate(timeout=float(sys.argv[2]))
+        except subprocess.TimeoutExpired:
+            _terminate_process_group(proc)
+            raise RuntimeError("candidate executor timed out")
+        result_stream.seek(0)
+        payload = result_stream.read()
     if proc.returncode != 0:
         raise RuntimeError("candidate executor failed")
-    reports = [
-        line for line in proc.stdout.splitlines() if line.startswith(EXECUTOR_PREFIX)
-    ]
-    if not reports:
+    if not payload:
         raise RuntimeError("candidate executor produced no result")
-    candidate_response = json_loads(reports[-1][len(EXECUTOR_PREFIX):])
+    candidate_response = json_loads(payload.decode("utf-8"))
     if candidate_response.get("ok"):
         response = {"ok": True, "value": _encode(_decode(candidate_response["value"]))}
     else:
@@ -167,6 +187,7 @@ exit_now(0)
 DRIVER_SUPPORT_SOURCE = _CODEC + '''\
 import json
 import os
+import signal
 import subprocess
 import sys
 from pathlib import Path
@@ -177,23 +198,35 @@ flush = sys.stdout.flush
 exit_now = os._exit
 here = Path(__file__).resolve().parent
 
+def _terminate_process_group(proc):
+    try:
+        os.killpg(proc.pid, signal.SIGKILL)
+    except ProcessLookupError:
+        pass
+    return proc.communicate()
+
 def _remote_call(name, args, kwargs):
     request = json.dumps(
         {"name": name, "args": _encode(args), "kwargs": _encode(kwargs)},
         separators=(",", ":"),
     )
-    proc = subprocess.run(
+    proc = subprocess.Popen(
         [sys.executable, "-I", "-c", WORKER_SOURCE, request, str(CALL_TIMEOUT_S)],
         cwd=here,
         stdin=subprocess.DEVNULL,
-        capture_output=True,
+        stdout=subprocess.PIPE,
+        stderr=subprocess.PIPE,
         text=True,
-        timeout=CALL_TIMEOUT_S,
-        check=False,
+        start_new_session=True,
     )
+    try:
+        stdout, _ = proc.communicate(timeout=SUPERVISOR_TIMEOUT_S)
+    except subprocess.TimeoutExpired:
+        _terminate_process_group(proc)
+        raise RuntimeError("candidate worker timed out")
     if proc.returncode != 0:
         raise RuntimeError("candidate worker failed")
-    reports = [line for line in proc.stdout.splitlines() if line.startswith(WORKER_PREFIX)]
+    reports = [line for line in stdout.splitlines() if line.startswith(WORKER_PREFIX)]
     if not reports:
         raise RuntimeError("candidate worker produced no report")
     response = json.loads(reports[-1][len(WORKER_PREFIX):])
@@ -213,11 +246,9 @@ class _RemoteFunction:
 
 def build_worker_source(worker_prefix: str) -> str:
     """Return a self-contained candidate worker with a private result prefix."""
-    executor = f"EXECUTOR_PREFIX = {EXECUTOR_PREFIX!r}\n" + EXECUTOR_SOURCE
     return (
         f"WORKER_PREFIX = {worker_prefix!r}\n"
-        f"EXECUTOR_PREFIX = {EXECUTOR_PREFIX!r}\n"
-        f"EXECUTOR_SOURCE = {executor!r}\n"
+        f"EXECUTOR_SOURCE = {EXECUTOR_SOURCE!r}\n"
         + WORKER_SOURCE
     )
 
@@ -238,6 +269,35 @@ def build_driver_source(
         "WORKER_PREFIX": worker_prefix,
         "WORKER_SOURCE": worker,
         "CALL_TIMEOUT_S": call_timeout_s,
+        "SUPERVISOR_TIMEOUT_S": call_timeout_s + 2,
     }
     header = "".join(f"{name} = {value!r}\n" for name, value in values.items())
     return header + DRIVER_SUPPORT_SOURCE + body
+
+
+def install_driver(path: Path, source: str) -> None:
+    """Replace an exact file/symlink entry and create a new driver without following links."""
+    path = Path(path)
+    try:
+        path.unlink()
+    except FileNotFoundError:
+        pass
+    flags = os.O_WRONLY | os.O_CREAT | os.O_EXCL | getattr(os, "O_NOFOLLOW", 0)
+    descriptor = os.open(path, flags, 0o600)
+    try:
+        with os.fdopen(descriptor, "w", encoding="utf-8") as stream:
+            stream.write(source)
+    except BaseException:
+        cleanup_driver(path)
+        raise
+
+
+def cleanup_driver(path: Path) -> OSError | None:
+    """Unlink only the exact driver entry, reporting rather than raising cleanup errors."""
+    try:
+        Path(path).unlink()
+    except FileNotFoundError:
+        return None
+    except OSError as exc:
+        return exc
+    return None

--- a/proteus/bench/humaneval.py
+++ b/proteus/bench/humaneval.py
@@ -1,0 +1,325 @@
+"""OpenAI HumanEval as lightweight external benchmark tasks.
+
+The MIT-licensed dataset from ``openai/human-eval`` is not vendored. Public prompts are
+seeded into the task workspace; canonical solutions and tests remain held out.
+"""
+
+from __future__ import annotations
+
+import gzip
+import json
+import os
+import secrets
+import subprocess
+import tempfile
+from pathlib import Path
+from urllib import request
+
+from proteus.bench.task import BenchTask
+from proteus.core.goal import EvalResult
+
+DATA_URL = (
+    "https://raw.githubusercontent.com/openai/human-eval/master/data/HumanEval.jsonl.gz"
+)
+GRADE_TIMEOUT_S = 60
+CALL_TIMEOUT_S = 15
+
+_CODEC = '''\
+import base64
+
+_type = type
+_isinstance = isinstance
+_bool = bool
+_int = int
+_float = float
+_complex = complex
+_str = str
+_bytes = bytes
+_list = list
+_tuple = tuple
+_set = set
+_frozenset = frozenset
+_dict = dict
+
+class _OpaqueValue:
+    def __init__(self, truthy):
+        self.truthy = truthy
+
+    def __bool__(self):
+        return self.truthy
+
+def _encode(value):
+    kind = _type(value)
+    if value is None:
+        return {"type": "none"}
+    if kind is _bool:
+        return {"type": "bool", "value": value}
+    if kind is _int:
+        return {"type": "int", "value": _str(value)}
+    if kind is _float:
+        return {"type": "float", "value": _str(value)}
+    if kind is _complex:
+        return {"type": "complex", "real": _str(value.real), "imag": _str(value.imag)}
+    if kind is _str:
+        return {"type": "str", "value": value}
+    if kind is _bytes:
+        return {"type": "bytes", "value": base64.b64encode(value).decode("ascii")}
+    if _isinstance(value, _list):
+        return {"type": "list", "items": [_encode(item) for item in value]}
+    if _isinstance(value, _tuple):
+        return {"type": "tuple", "items": [_encode(item) for item in value]}
+    if _isinstance(value, (_set, _frozenset)):
+        return {"type": "set", "items": [_encode(item) for item in value]}
+    if _isinstance(value, _dict):
+        return {"type": "dict", "items": [[_encode(k), _encode(v)] for k, v in value.items()]}
+    return {"type": "opaque", "truthy": _bool(value)}
+
+def _decode(node):
+    kind = node["type"]
+    if kind == "none":
+        return None
+    if kind == "bool":
+        return _bool(node["value"])
+    if kind == "int":
+        return _int(node["value"])
+    if kind == "float":
+        return _float(node["value"])
+    if kind == "complex":
+        return _complex(_float(node["real"]), _float(node["imag"]))
+    if kind == "str":
+        return _str(node["value"])
+    if kind == "bytes":
+        return base64.b64decode(node["value"], validate=True)
+    if kind == "list":
+        return [_decode(item) for item in node["items"]]
+    if kind == "tuple":
+        return _tuple(_decode(item) for item in node["items"])
+    if kind == "set":
+        return {_decode(item) for item in node["items"]}
+    if kind == "dict":
+        return {_decode(k): _decode(v) for k, v in node["items"]}
+    if kind == "opaque":
+        return _OpaqueValue(_bool(node["truthy"]))
+    raise ValueError(f"unknown HumanEval value type: {kind!r}")
+'''
+
+_WORKER = _CODEC + '''\
+import builtins
+import json
+import os
+import sys
+from pathlib import Path
+
+trusted_exec = exec
+trusted_compile = compile
+caught = BaseException
+json_loads = json.loads
+json_dumps = json.dumps
+emit = sys.stdout.write
+flush = sys.stdout.flush
+exit_now = os._exit
+here = Path.cwd()
+solution = here / "solution.py"
+namespace = {"__name__": "__main__", "__file__": str(solution),
+             "__builtins__": dict(vars(builtins))}
+try:
+    request = json_loads(sys.argv[1])
+    source = solution.read_text(encoding="utf-8")
+    trusted_exec(trusted_compile(source, str(solution), "exec"), namespace)
+    function = namespace[ENTRY_POINT]
+    value = function(*_decode(request["args"]), **_decode(request["kwargs"]))
+    response = {"ok": True, "value": _encode(value)}
+except caught as exc:
+    response = {"ok": False, "error": f"{_type(exc).__name__}: {exc}"}
+emit(WORKER_PREFIX + json_dumps(response, separators=(",", ":")) + "\\n")
+flush()
+exit_now(0)
+'''
+
+_DRIVER = _CODEC + '''\
+import json
+import os
+import subprocess
+import sys
+from pathlib import Path
+
+caught = BaseException
+emit = sys.stdout.write
+flush = sys.stdout.flush
+exit_now = os._exit
+here = Path.cwd()
+
+def _remote_call(args, kwargs):
+    request = json.dumps(
+        {"args": _encode(args), "kwargs": _encode(kwargs)},
+        separators=(",", ":"),
+    )
+    proc = subprocess.run(
+        [sys.executable, "-c", WORKER_SOURCE, request],
+        cwd=here,
+        stdin=subprocess.DEVNULL,
+        capture_output=True,
+        text=True,
+        timeout=CALL_TIMEOUT_S,
+        check=False,
+    )
+    if proc.returncode != 0:
+        raise RuntimeError("candidate worker failed")
+    reports = [line for line in proc.stdout.splitlines() if line.startswith(WORKER_PREFIX)]
+    if not reports:
+        raise RuntimeError("candidate worker produced no report")
+    response = json.loads(reports[-1][len(WORKER_PREFIX):])
+    if not response.get("ok"):
+        raise RuntimeError(response.get("error", "candidate call failed"))
+    return _decode(response["value"])
+
+class _RemoteFunction:
+    def __call__(self, *args, **kwargs):
+        return _remote_call(args, kwargs)
+
+try:
+    Path(__file__).resolve().unlink()
+    namespace = {"__name__": "__main__"}
+    exec(TEST_SOURCE, namespace)
+    namespace["check"](_RemoteFunction())
+    passed = True
+except caught:
+    passed = False
+emit(REPORT_PREFIX + ("pass" if passed else "fail") + "\\n")
+flush()
+exit_now(0)
+'''
+
+
+def dataset_path(dataset_file: str | os.PathLike | None = None) -> Path:
+    """Resolve an explicit, environment-provided, or cached HumanEval dataset."""
+    if dataset_file:
+        return Path(dataset_file).expanduser()
+    env = os.environ.get("PROTEUS_HUMANEVAL_PATH")
+    if env:
+        return Path(env).expanduser()
+    cache = Path.home() / ".cache" / "proteus" / "humaneval" / "HumanEval.jsonl.gz"
+    if not cache.exists():
+        cache.parent.mkdir(parents=True, exist_ok=True)
+        with request.urlopen(DATA_URL, timeout=30) as response:
+            payload = response.read()
+        temp_path = None
+        try:
+            with tempfile.NamedTemporaryFile(
+                dir=cache.parent, suffix=".jsonl.gz", delete=False
+            ) as tmp:
+                tmp.write(payload)
+                temp_path = Path(tmp.name)
+            _records(temp_path)
+            temp_path.replace(cache)
+        finally:
+            if temp_path is not None:
+                temp_path.unlink(missing_ok=True)
+    return cache
+
+
+def _records(path: Path) -> dict[str, dict]:
+    opener = gzip.open if path.suffix == ".gz" else open
+    with opener(path, "rt", encoding="utf-8") as stream:
+        return {
+            row["task_id"]: row
+            for line in stream
+            if line.strip()
+            for row in [json.loads(line)]
+        }
+
+
+def list_tasks(dataset_file: str | os.PathLike | None = None) -> list[str]:
+    """Task IDs available in the HumanEval dataset."""
+    return list(_records(dataset_path(dataset_file)))
+
+
+def _load(path: Path, task_id: str) -> dict:
+    try:
+        return _records(path)[task_id]
+    except KeyError:
+        raise KeyError(
+            f"unknown HumanEval task {task_id!r}; see proteus.bench.humaneval.list_tasks()"
+        ) from None
+
+
+def _setup(ws: Path, spec: dict) -> None:
+    (ws / "README.md").write_text(
+        f"# {spec['task_id']}\n\nImplement the function in `solution.py`.\n",
+        encoding="utf-8",
+    )
+    (ws / "solution.py").write_text(spec["prompt"], encoding="utf-8")
+
+
+def _grade(ws: Path, spec: dict, name: str, *, sandbox=None) -> EvalResult:
+    report_prefix = f"PROTEUS_HUMANEVAL_RESULT:{secrets.token_hex(16)}:"
+    worker_prefix = f"PROTEUS_HUMANEVAL_VALUE:{secrets.token_hex(16)}:"
+    worker_source = (
+        f"ENTRY_POINT = {spec['entry_point']!r}\nWORKER_PREFIX = {worker_prefix!r}\n"
+        + _WORKER
+    )
+    driver = ws / "_grade.py"
+    driver.write_text(
+        f"TEST_SOURCE = {spec['test']!r}\n"
+        f"REPORT_PREFIX = {report_prefix!r}\n"
+        f"WORKER_PREFIX = {worker_prefix!r}\n"
+        f"WORKER_SOURCE = {worker_source!r}\n"
+        f"CALL_TIMEOUT_S = {CALL_TIMEOUT_S}\n"
+        + _DRIVER,
+        encoding="utf-8",
+    )
+    try:
+        from proteus.bench.sandbox import run_python
+
+        proc = run_python(
+            ws, "_grade.py", timeout_s=GRADE_TIMEOUT_S, sandbox=sandbox, isolated=True
+        )
+    except subprocess.TimeoutExpired:
+        return EvalResult(
+            name=name,
+            score=0.0,
+            passed=False,
+            detail=f"grading timed out after {GRADE_TIMEOUT_S}s",
+        )
+    finally:
+        driver.unlink(missing_ok=True)
+
+    stdout = getattr(proc, "stdout", "")
+    stderr = getattr(proc, "stderr", "")
+    stdout = stdout if isinstance(stdout, str) else ""
+    stderr = stderr if isinstance(stderr, str) else ""
+    reports = [line for line in stdout.splitlines() if line.startswith(report_prefix)]
+    if getattr(proc, "returncode", 1) != 0 or not reports:
+        diagnostic = (stderr or stdout)[-200:]
+        return EvalResult(
+            name=name,
+            score=0.0,
+            passed=False,
+            detail=f"grader produced no report: {diagnostic}",
+        )
+
+    passed = reports[-1][len(report_prefix):] == "pass"
+    return EvalResult(
+        name=name,
+        score=1.0 if passed else 0.0,
+        passed=passed,
+        detail=f"official check {'passed' if passed else 'failed'}",
+    )
+
+
+def humaneval_task(
+    task_id: str, dataset_file: str | os.PathLike | None = None
+) -> BenchTask:
+    """Create one HumanEval problem as a ``BenchTask``."""
+    spec = _load(dataset_path(dataset_file), task_id)
+    name = f"humaneval:{spec['task_id']}"
+    return BenchTask(
+        id=name,
+        goal_text=(
+            f"Solve {spec['task_id']} in `task/solution.py`; official tests are held out."
+        ),
+        setup=lambda ws, s=spec: _setup(ws, s),
+        grade=lambda ws, sandbox=None, s=spec, n=name: _grade(
+            ws, s, n, sandbox=sandbox
+        ),
+    )

--- a/proteus/bench/humaneval.py
+++ b/proteus/bench/humaneval.py
@@ -14,6 +14,7 @@ import subprocess
 from pathlib import Path
 
 from proteus.bench._datasets import download_verified
+from proteus.bench._isolation import build_driver_source
 from proteus.bench.task import BenchTask
 from proteus.core.goal import EvalResult
 
@@ -25,164 +26,12 @@ DATA_SHA256 = "b796127e635a67f93fb35c04f4cb03cf06f38c8072ee7cee8833d7bee06979ef"
 GRADE_TIMEOUT_S = 60
 CALL_TIMEOUT_S = 15
 
-_CODEC = '''\
-import base64
-
-_type = type
-_isinstance = isinstance
-_bool = bool
-_int = int
-_float = float
-_complex = complex
-_str = str
-_bytes = bytes
-_list = list
-_tuple = tuple
-_set = set
-_frozenset = frozenset
-_dict = dict
-
-class _OpaqueValue:
-    def __init__(self, truthy):
-        self.truthy = truthy
-
-    def __bool__(self):
-        return self.truthy
-
-def _encode(value):
-    kind = _type(value)
-    if value is None:
-        return {"type": "none"}
-    if kind is _bool:
-        return {"type": "bool", "value": value}
-    if kind is _int:
-        return {"type": "int", "value": _str(value)}
-    if kind is _float:
-        return {"type": "float", "value": _str(value)}
-    if kind is _complex:
-        return {"type": "complex", "real": _str(value.real), "imag": _str(value.imag)}
-    if kind is _str:
-        return {"type": "str", "value": value}
-    if kind is _bytes:
-        return {"type": "bytes", "value": base64.b64encode(value).decode("ascii")}
-    if _isinstance(value, _list):
-        return {"type": "list", "items": [_encode(item) for item in value]}
-    if _isinstance(value, _tuple):
-        return {"type": "tuple", "items": [_encode(item) for item in value]}
-    if _isinstance(value, (_set, _frozenset)):
-        return {"type": "set", "items": [_encode(item) for item in value]}
-    if _isinstance(value, _dict):
-        return {"type": "dict", "items": [[_encode(k), _encode(v)] for k, v in value.items()]}
-    return {"type": "opaque", "truthy": _bool(value)}
-
-def _decode(node):
-    kind = node["type"]
-    if kind == "none":
-        return None
-    if kind == "bool":
-        return _bool(node["value"])
-    if kind == "int":
-        return _int(node["value"])
-    if kind == "float":
-        return _float(node["value"])
-    if kind == "complex":
-        return _complex(_float(node["real"]), _float(node["imag"]))
-    if kind == "str":
-        return _str(node["value"])
-    if kind == "bytes":
-        return base64.b64decode(node["value"], validate=True)
-    if kind == "list":
-        return [_decode(item) for item in node["items"]]
-    if kind == "tuple":
-        return _tuple(_decode(item) for item in node["items"])
-    if kind == "set":
-        return {_decode(item) for item in node["items"]}
-    if kind == "dict":
-        return {_decode(k): _decode(v) for k, v in node["items"]}
-    if kind == "opaque":
-        return _OpaqueValue(_bool(node["truthy"]))
-    raise ValueError(f"unknown HumanEval value type: {kind!r}")
-'''
-
-_WORKER = _CODEC + '''\
-import builtins
-import json
-import os
-import sys
-from pathlib import Path
-
-trusted_exec = exec
-trusted_compile = compile
-caught = BaseException
-json_loads = json.loads
-json_dumps = json.dumps
-emit = sys.stdout.write
-flush = sys.stdout.flush
-exit_now = os._exit
-here = Path.cwd()
-solution = here / "solution.py"
-namespace = {"__name__": "__main__", "__file__": str(solution),
-             "__builtins__": dict(vars(builtins))}
-try:
-    request = json_loads(sys.argv[1])
-    source = solution.read_text(encoding="utf-8")
-    trusted_exec(trusted_compile(source, str(solution), "exec"), namespace)
-    function = namespace[ENTRY_POINT]
-    value = function(*_decode(request["args"]), **_decode(request["kwargs"]))
-    response = {"ok": True, "value": _encode(value)}
-except caught as exc:
-    response = {"ok": False, "error": f"{_type(exc).__name__}: {exc}"}
-emit(WORKER_PREFIX + json_dumps(response, separators=(",", ":")) + "\\n")
-flush()
-exit_now(0)
-'''
-
-_DRIVER = _CODEC + '''\
-import json
-import os
-import subprocess
-import sys
-from pathlib import Path
-
-caught = BaseException
-emit = sys.stdout.write
-flush = sys.stdout.flush
-exit_now = os._exit
-here = Path.cwd()
-
-def _remote_call(args, kwargs):
-    request = json.dumps(
-        {"args": _encode(args), "kwargs": _encode(kwargs)},
-        separators=(",", ":"),
-    )
-    proc = subprocess.run(
-        [sys.executable, "-c", WORKER_SOURCE, request],
-        cwd=here,
-        stdin=subprocess.DEVNULL,
-        capture_output=True,
-        text=True,
-        timeout=CALL_TIMEOUT_S,
-        check=False,
-    )
-    if proc.returncode != 0:
-        raise RuntimeError("candidate worker failed")
-    reports = [line for line in proc.stdout.splitlines() if line.startswith(WORKER_PREFIX)]
-    if not reports:
-        raise RuntimeError("candidate worker produced no report")
-    response = json.loads(reports[-1][len(WORKER_PREFIX):])
-    if not response.get("ok"):
-        raise RuntimeError(response.get("error", "candidate call failed"))
-    return _decode(response["value"])
-
-class _RemoteFunction:
-    def __call__(self, *args, **kwargs):
-        return _remote_call(args, kwargs)
-
+_DRIVER_BODY = '''\
 try:
     Path(__file__).resolve().unlink()
     namespace = {"__name__": "__main__"}
     exec(PROMPT_SOURCE, namespace)
-    candidate = _RemoteFunction()
+    candidate = _RemoteFunction(ENTRY_POINT)
     namespace[ENTRY_POINT] = candidate
     exec(TEST_SOURCE, namespace)
     namespace["check"](candidate)
@@ -248,20 +97,19 @@ def _setup(ws: Path, spec: dict) -> None:
 def _grade(ws: Path, spec: dict, name: str, *, sandbox=None) -> EvalResult:
     report_prefix = f"PROTEUS_HUMANEVAL_RESULT:{secrets.token_hex(16)}:"
     worker_prefix = f"PROTEUS_HUMANEVAL_VALUE:{secrets.token_hex(16)}:"
-    worker_source = (
-        f"ENTRY_POINT = {spec['entry_point']!r}\nWORKER_PREFIX = {worker_prefix!r}\n"
-        + _WORKER
-    )
     driver = ws / "_grade.py"
     driver.write_text(
-        f"PROMPT_SOURCE = {spec['prompt']!r}\n"
-        f"TEST_SOURCE = {spec['test']!r}\n"
-        f"ENTRY_POINT = {spec['entry_point']!r}\n"
-        f"REPORT_PREFIX = {report_prefix!r}\n"
-        f"WORKER_PREFIX = {worker_prefix!r}\n"
-        f"WORKER_SOURCE = {worker_source!r}\n"
-        f"CALL_TIMEOUT_S = {CALL_TIMEOUT_S}\n"
-        + _DRIVER,
+        build_driver_source(
+            report_prefix=report_prefix,
+            worker_prefix=worker_prefix,
+            call_timeout_s=CALL_TIMEOUT_S,
+            bindings={
+                "PROMPT_SOURCE": spec["prompt"],
+                "TEST_SOURCE": spec["test"],
+                "ENTRY_POINT": spec["entry_point"],
+            },
+            body=_DRIVER_BODY,
+        ),
         encoding="utf-8",
     )
     try:

--- a/proteus/bench/humaneval.py
+++ b/proteus/bench/humaneval.py
@@ -180,8 +180,11 @@ class _RemoteFunction:
 try:
     Path(__file__).resolve().unlink()
     namespace = {"__name__": "__main__"}
+    exec(PROMPT_SOURCE, namespace)
+    candidate = _RemoteFunction()
+    namespace[ENTRY_POINT] = candidate
     exec(TEST_SOURCE, namespace)
-    namespace["check"](_RemoteFunction())
+    namespace["check"](candidate)
     passed = True
 except caught:
     passed = False
@@ -260,7 +263,9 @@ def _grade(ws: Path, spec: dict, name: str, *, sandbox=None) -> EvalResult:
     )
     driver = ws / "_grade.py"
     driver.write_text(
+        f"PROMPT_SOURCE = {spec['prompt']!r}\n"
         f"TEST_SOURCE = {spec['test']!r}\n"
+        f"ENTRY_POINT = {spec['entry_point']!r}\n"
         f"REPORT_PREFIX = {report_prefix!r}\n"
         f"WORKER_PREFIX = {worker_prefix!r}\n"
         f"WORKER_SOURCE = {worker_source!r}\n"

--- a/proteus/bench/humaneval.py
+++ b/proteus/bench/humaneval.py
@@ -14,7 +14,7 @@ import subprocess
 from pathlib import Path
 
 from proteus.bench._datasets import download_verified
-from proteus.bench._isolation import build_driver_source
+from proteus.bench._isolation import cleanup_driver, build_driver_source, install_driver
 from proteus.bench.task import BenchTask
 from proteus.core.goal import EvalResult
 
@@ -28,7 +28,7 @@ CALL_TIMEOUT_S = 15
 
 _DRIVER_BODY = '''\
 try:
-    Path(__file__).resolve().unlink()
+    Path(__file__).unlink()
     namespace = {"__name__": "__main__"}
     exec(PROMPT_SOURCE, namespace)
     candidate = _RemoteFunction(ENTRY_POINT)
@@ -98,20 +98,28 @@ def _grade(ws: Path, spec: dict, name: str, *, sandbox=None) -> EvalResult:
     report_prefix = f"PROTEUS_HUMANEVAL_RESULT:{secrets.token_hex(16)}:"
     worker_prefix = f"PROTEUS_HUMANEVAL_VALUE:{secrets.token_hex(16)}:"
     driver = ws / "_grade.py"
-    driver.write_text(
-        build_driver_source(
-            report_prefix=report_prefix,
-            worker_prefix=worker_prefix,
-            call_timeout_s=CALL_TIMEOUT_S,
-            bindings={
-                "PROMPT_SOURCE": spec["prompt"],
-                "TEST_SOURCE": spec["test"],
-                "ENTRY_POINT": spec["entry_point"],
-            },
-            body=_DRIVER_BODY,
-        ),
-        encoding="utf-8",
+    source = build_driver_source(
+        report_prefix=report_prefix,
+        worker_prefix=worker_prefix,
+        call_timeout_s=CALL_TIMEOUT_S,
+        bindings={
+            "PROMPT_SOURCE": spec["prompt"],
+            "TEST_SOURCE": spec["test"],
+            "ENTRY_POINT": spec["entry_point"],
+        },
+        body=_DRIVER_BODY,
     )
+    try:
+        install_driver(driver, source)
+    except OSError as exc:
+        return EvalResult(
+            name=name,
+            score=0.0,
+            passed=False,
+            detail=f"grader setup failed ({type(exc).__name__}: {exc})",
+        )
+
+    timed_out = False
     try:
         from proteus.bench.sandbox import run_python
 
@@ -119,14 +127,26 @@ def _grade(ws: Path, spec: dict, name: str, *, sandbox=None) -> EvalResult:
             ws, "_grade.py", timeout_s=GRADE_TIMEOUT_S, sandbox=sandbox, isolated=True
         )
     except subprocess.TimeoutExpired:
+        timed_out = True
+
+    cleanup_error = cleanup_driver(driver)
+    if cleanup_error is not None:
+        return EvalResult(
+            name=name,
+            score=0.0,
+            passed=False,
+            detail=(
+                "grader cleanup failed "
+                f"({type(cleanup_error).__name__}: {cleanup_error})"
+            ),
+        )
+    if timed_out:
         return EvalResult(
             name=name,
             score=0.0,
             passed=False,
             detail=f"grading timed out after {GRADE_TIMEOUT_S}s",
         )
-    finally:
-        driver.unlink(missing_ok=True)
 
     stdout = getattr(proc, "stdout", "")
     stderr = getattr(proc, "stderr", "")

--- a/proteus/bench/humaneval.py
+++ b/proteus/bench/humaneval.py
@@ -11,16 +11,17 @@ import json
 import os
 import secrets
 import subprocess
-import tempfile
 from pathlib import Path
-from urllib import request
 
+from proteus.bench._datasets import download_verified
 from proteus.bench.task import BenchTask
 from proteus.core.goal import EvalResult
 
 DATA_URL = (
-    "https://raw.githubusercontent.com/openai/human-eval/master/data/HumanEval.jsonl.gz"
+    "https://raw.githubusercontent.com/openai/human-eval/"
+    "6d43fb980f9fee3c892a914eda09951f772ad10d/data/HumanEval.jsonl.gz"
 )
+DATA_SHA256 = "b796127e635a67f93fb35c04f4cb03cf06f38c8072ee7cee8833d7bee06979ef"
 GRADE_TIMEOUT_S = 60
 CALL_TIMEOUT_S = 15
 
@@ -202,23 +203,13 @@ def dataset_path(dataset_file: str | os.PathLike | None = None) -> Path:
     if env:
         return Path(env).expanduser()
     cache = Path.home() / ".cache" / "proteus" / "humaneval" / "HumanEval.jsonl.gz"
-    if not cache.exists():
-        cache.parent.mkdir(parents=True, exist_ok=True)
-        with request.urlopen(DATA_URL, timeout=30) as response:
-            payload = response.read()
-        temp_path = None
-        try:
-            with tempfile.NamedTemporaryFile(
-                dir=cache.parent, suffix=".jsonl.gz", delete=False
-            ) as tmp:
-                tmp.write(payload)
-                temp_path = Path(tmp.name)
-            _records(temp_path)
-            temp_path.replace(cache)
-        finally:
-            if temp_path is not None:
-                temp_path.unlink(missing_ok=True)
-    return cache
+    return download_verified(
+        name="HumanEval",
+        url=DATA_URL,
+        expected_sha256=DATA_SHA256,
+        cache=cache,
+        validate=_records,
+    )
 
 
 def _records(path: Path) -> dict[str, dict]:

--- a/proteus/bench/mbpp.py
+++ b/proteus/bench/mbpp.py
@@ -15,17 +15,17 @@ import json
 import os
 import secrets
 import subprocess
-import tempfile
 from pathlib import Path
-from urllib import request
 
+from proteus.bench._datasets import download_verified
 from proteus.bench.task import BenchTask
 from proteus.core.goal import EvalResult
 
 DATA_URL = (
     "https://raw.githubusercontent.com/google-research/google-research/"
-    "master/mbpp/sanitized-mbpp.json"
+    "e20eb00d074cdb569ee27318f112ea1e85bbb98f/mbpp/sanitized-mbpp.json"
 )
+DATA_SHA256 = "ca95deaa9a01ef0a6f439f88bcf0dd3db3563d22f22aad6cae04ebb9a8d8c8e9"
 GRADE_TIMEOUT_S = 60
 CALL_TIMEOUT_S = 15
 
@@ -220,23 +220,13 @@ def dataset_path(dataset_file: str | os.PathLike | None = None) -> Path:
     if env:
         return Path(env).expanduser()
     cache = Path.home() / ".cache" / "proteus" / "mbpp" / "sanitized-mbpp.json"
-    if not cache.exists():
-        cache.parent.mkdir(parents=True, exist_ok=True)
-        with request.urlopen(DATA_URL, timeout=30) as response:
-            payload = response.read()
-        rows = json.loads(payload.decode("utf-8"))
-        if not isinstance(rows, list):
-            raise ValueError("sanitized MBPP download is not a JSON list")
-        temp_path = None
-        try:
-            with tempfile.NamedTemporaryFile(dir=cache.parent, delete=False) as tmp:
-                tmp.write(payload)
-                temp_path = Path(tmp.name)
-            temp_path.replace(cache)
-        finally:
-            if temp_path is not None:
-                temp_path.unlink(missing_ok=True)
-    return cache
+    return download_verified(
+        name="MBPP",
+        url=DATA_URL,
+        expected_sha256=DATA_SHA256,
+        cache=cache,
+        validate=_records,
+    )
 
 
 def _records(path: Path) -> dict[str, dict]:

--- a/proteus/bench/mbpp.py
+++ b/proteus/bench/mbpp.py
@@ -18,6 +18,7 @@ import subprocess
 from pathlib import Path
 
 from proteus.bench._datasets import download_verified
+from proteus.bench._isolation import build_driver_source
 from proteus.bench.task import BenchTask
 from proteus.core.goal import EvalResult
 
@@ -29,159 +30,7 @@ DATA_SHA256 = "ca95deaa9a01ef0a6f439f88bcf0dd3db3563d22f22aad6cae04ebb9a8d8c8e9"
 GRADE_TIMEOUT_S = 60
 CALL_TIMEOUT_S = 15
 
-_CODEC = '''\
-import base64
-
-_type = type
-_isinstance = isinstance
-_bool = bool
-_int = int
-_float = float
-_complex = complex
-_str = str
-_bytes = bytes
-_list = list
-_tuple = tuple
-_set = set
-_frozenset = frozenset
-_dict = dict
-
-class _OpaqueValue:
-    def __init__(self, truthy):
-        self.truthy = truthy
-
-    def __bool__(self):
-        return self.truthy
-
-def _encode(value):
-    kind = _type(value)
-    if value is None:
-        return {"type": "none"}
-    if kind is _bool:
-        return {"type": "bool", "value": value}
-    if kind is _int:
-        return {"type": "int", "value": _str(value)}
-    if kind is _float:
-        return {"type": "float", "value": _str(value)}
-    if kind is _complex:
-        return {"type": "complex", "real": _str(value.real), "imag": _str(value.imag)}
-    if kind is _str:
-        return {"type": "str", "value": value}
-    if kind is _bytes:
-        return {"type": "bytes", "value": base64.b64encode(value).decode("ascii")}
-    if _isinstance(value, _list):
-        return {"type": "list", "items": [_encode(item) for item in value]}
-    if _isinstance(value, _tuple):
-        return {"type": "tuple", "items": [_encode(item) for item in value]}
-    if _isinstance(value, (_set, _frozenset)):
-        return {"type": "set", "items": [_encode(item) for item in value]}
-    if _isinstance(value, _dict):
-        return {"type": "dict", "items": [[_encode(k), _encode(v)] for k, v in value.items()]}
-    return {"type": "opaque", "truthy": _bool(value)}
-
-def _decode(node):
-    kind = node["type"]
-    if kind == "none":
-        return None
-    if kind == "bool":
-        return _bool(node["value"])
-    if kind == "int":
-        return _int(node["value"])
-    if kind == "float":
-        return _float(node["value"])
-    if kind == "complex":
-        return _complex(_float(node["real"]), _float(node["imag"]))
-    if kind == "str":
-        return _str(node["value"])
-    if kind == "bytes":
-        return base64.b64decode(node["value"], validate=True)
-    if kind == "list":
-        return [_decode(item) for item in node["items"]]
-    if kind == "tuple":
-        return _tuple(_decode(item) for item in node["items"])
-    if kind == "set":
-        return {_decode(item) for item in node["items"]}
-    if kind == "dict":
-        return {_decode(k): _decode(v) for k, v in node["items"]}
-    if kind == "opaque":
-        return _OpaqueValue(_bool(node["truthy"]))
-    raise ValueError(f"unknown MBPP value type: {kind!r}")
-'''
-
-_WORKER = _CODEC + '''\
-import builtins
-import json
-import os
-import sys
-from pathlib import Path
-
-trusted_exec = exec
-trusted_compile = compile
-caught = BaseException
-json_loads = json.loads
-json_dumps = json.dumps
-emit = sys.stdout.write
-flush = sys.stdout.flush
-exit_now = os._exit
-here = Path.cwd()
-solution = here / "solution.py"
-namespace = {"__name__": "__main__", "__file__": str(solution),
-             "__builtins__": dict(vars(builtins))}
-try:
-    request = json_loads(sys.argv[1])
-    source = solution.read_text(encoding="utf-8")
-    trusted_exec(trusted_compile(source, str(solution), "exec"), namespace)
-    function = namespace[request["name"]]
-    value = function(*_decode(request["args"]), **_decode(request["kwargs"]))
-    response = {"ok": True, "value": _encode(value)}
-except caught as exc:
-    response = {"ok": False, "error": f"{_type(exc).__name__}: {exc}"}
-emit(WORKER_PREFIX + json_dumps(response, separators=(",", ":")) + "\\n")
-flush()
-exit_now(0)
-'''
-
-_DRIVER = _CODEC + '''\
-import json
-import os
-import subprocess
-import sys
-from pathlib import Path
-
-emit = sys.stdout.write
-flush = sys.stdout.flush
-exit_now = os._exit
-here = Path(__file__).resolve().parent
-
-def _remote_call(name, args, kwargs):
-    request = json.dumps(
-        {"name": name, "args": _encode(args), "kwargs": _encode(kwargs)},
-        separators=(",", ":"),
-    )
-    proc = subprocess.run(
-        [sys.executable, "-c", WORKER_SOURCE, request],
-        cwd=here,
-        stdin=subprocess.DEVNULL,
-        capture_output=True,
-        text=True,
-        timeout=CALL_TIMEOUT_S,
-        check=False,
-    )
-    if proc.returncode != 0:
-        raise RuntimeError("candidate worker failed")
-    reports = [line for line in proc.stdout.splitlines() if line.startswith(WORKER_PREFIX)]
-    response = json.loads(reports[-1][len(WORKER_PREFIX):])
-    if not response.get("ok"):
-        raise RuntimeError(response.get("error", "candidate call failed"))
-    return _decode(response["value"])
-
-class _RemoteFunction:
-    def __init__(self, name):
-        self.name = name
-
-    def __call__(self, *args, **kwargs):
-        return _remote_call(self.name, args, kwargs)
-
+_DRIVER_BODY = '''\
 def _report(passed):
     emit(REPORT_PREFIX + str(passed) + "/" + str(len(TESTS)) + "\\n")
     flush()
@@ -198,7 +47,7 @@ try:
         exec(statement, namespace)
     for name in ENTRY_POINTS:
         namespace[name] = _RemoteFunction(name)
-except BaseException:
+except caught:
     _report(0)
 
 passed = 0
@@ -206,7 +55,7 @@ for assertion in TESTS:
     try:
         exec(assertion, namespace)
         passed += 1
-    except BaseException:
+    except caught:
         pass
 _report(passed)
 '''
@@ -244,8 +93,9 @@ def _load(path: Path, task_id: int | str) -> dict:
     try:
         return _records(path)[key]
     except KeyError:
-        raise KeyError(f"unknown MBPP task {key!r}; see proteus.bench.mbpp.list_tasks()") \
-            from None
+        raise KeyError(
+            f"unknown MBPP task {key!r}; see proteus.bench.mbpp.list_tasks()"
+        ) from None
 
 
 def _setup(ws: Path, spec: dict) -> None:
@@ -275,16 +125,17 @@ def _reference_imports(spec: dict) -> list[str]:
 
 
 def _driver(spec: dict, report_prefix: str, worker_prefix: str) -> str:
-    imports = list(spec.get("test_imports", []))
-    tests = list(spec["test_list"])
-    worker_source = f"WORKER_PREFIX = {worker_prefix!r}\n" + _WORKER
-    return (
-        f"TEST_IMPORTS = {imports!r}\nREFERENCE_IMPORTS = {_reference_imports(spec)!r}\n"
-        f"TESTS = {tests!r}\n"
-        f"ENTRY_POINTS = {_entry_points(spec)!r}\n"
-        f"REPORT_PREFIX = {report_prefix!r}\nWORKER_PREFIX = {worker_prefix!r}\n"
-        f"WORKER_SOURCE = {worker_source!r}\nCALL_TIMEOUT_S = {CALL_TIMEOUT_S}\n"
-        + _DRIVER
+    return build_driver_source(
+        report_prefix=report_prefix,
+        worker_prefix=worker_prefix,
+        call_timeout_s=CALL_TIMEOUT_S,
+        bindings={
+            "TEST_IMPORTS": list(spec.get("test_imports", [])),
+            "REFERENCE_IMPORTS": _reference_imports(spec),
+            "TESTS": list(spec["test_list"]),
+            "ENTRY_POINTS": _entry_points(spec),
+        },
+        body=_DRIVER_BODY,
     )
 
 

--- a/proteus/bench/mbpp.py
+++ b/proteus/bench/mbpp.py
@@ -18,7 +18,7 @@ import subprocess
 from pathlib import Path
 
 from proteus.bench._datasets import download_verified
-from proteus.bench._isolation import build_driver_source
+from proteus.bench._isolation import cleanup_driver, build_driver_source, install_driver
 from proteus.bench.task import BenchTask
 from proteus.core.goal import EvalResult
 
@@ -37,7 +37,7 @@ def _report(passed):
     exit_now(0)
 
 try:
-    Path(__file__).resolve().unlink()
+    Path(__file__).unlink()
 except OSError:
     _report(0)
 
@@ -143,7 +143,17 @@ def _grade(ws: Path, spec: dict, name: str, *, sandbox=None) -> EvalResult:
     report_prefix = f"PROTEUS_MBPP_RESULT:{secrets.token_hex(16)}:"
     worker_prefix = f"PROTEUS_MBPP_VALUE:{secrets.token_hex(16)}:"
     driver = ws / "_grade.py"
-    driver.write_text(_driver(spec, report_prefix, worker_prefix), encoding="utf-8")
+    try:
+        install_driver(driver, _driver(spec, report_prefix, worker_prefix))
+    except OSError as exc:
+        return EvalResult(
+            name=name,
+            score=0.0,
+            passed=False,
+            detail=f"grader setup failed ({type(exc).__name__}: {exc})",
+        )
+
+    timed_out = False
     try:
         from proteus.bench.sandbox import run_python
 
@@ -151,14 +161,26 @@ def _grade(ws: Path, spec: dict, name: str, *, sandbox=None) -> EvalResult:
             ws, "_grade.py", timeout_s=GRADE_TIMEOUT_S, sandbox=sandbox, isolated=True
         )
     except subprocess.TimeoutExpired:
+        timed_out = True
+
+    cleanup_error = cleanup_driver(driver)
+    if cleanup_error is not None:
+        return EvalResult(
+            name=name,
+            score=0.0,
+            passed=False,
+            detail=(
+                "grader cleanup failed "
+                f"({type(cleanup_error).__name__}: {cleanup_error})"
+            ),
+        )
+    if timed_out:
         return EvalResult(
             name=name,
             score=0.0,
             passed=False,
             detail=f"grading timed out after {GRADE_TIMEOUT_S}s",
         )
-    finally:
-        driver.unlink(missing_ok=True)
 
     expected = len(spec["test_list"])
     stdout = getattr(proc, "stdout", "")

--- a/proteus/cli.py
+++ b/proteus/cli.py
@@ -162,7 +162,8 @@ def _evaluator(spec: str, adapter_factory):
     """Parse one --evaluator: `<what>[@hidden|@observe]`. Returns (spec, task | None).
 
     measurement: units:<surface-name> | tool-calls | step
-    benchmark:   local:<task> | polyglot:<exercise> | mbpp:<task-id>
+    benchmark:   local:<task> | polyglot:<exercise> | mbpp:<task-id> |
+                 humaneval:<task-id>
     custom:      contains:<relpath>:<needle>
     """
     from proteus.bench.task import as_evaluator
@@ -173,7 +174,7 @@ def _evaluator(spec: str, adapter_factory):
         raise SystemExit(f"bad --evaluator {spec!r}: visibility is @hidden or @observe")
     visibility = Visibility(vis) if vis else Visibility.HIDDEN
     kind, _, arg = body.partition(":")
-    if kind in ("local", "polyglot", "mbpp") and arg:
+    if kind in ("local", "polyglot", "mbpp", "humaneval") and arg:
         try:
             if kind == "local":
                 from proteus.bench.local import local_task
@@ -181,9 +182,12 @@ def _evaluator(spec: str, adapter_factory):
             elif kind == "polyglot":
                 from proteus.bench.polyglot import polyglot_task
                 task = polyglot_task(arg)
-            else:
+            elif kind == "mbpp":
                 from proteus.bench.mbpp import mbpp_task
                 task = mbpp_task(arg)
+            else:
+                from proteus.bench.humaneval import humaneval_task
+                task = humaneval_task(arg)
         except KeyError as exc:
             raise SystemExit(str(exc)) from None
         return EvaluatorSpec(name=task.id, run=as_evaluator(task), kind="benchmark",
@@ -217,7 +221,7 @@ def _evaluator(spec: str, adapter_factory):
     raise SystemExit(
         f"bad --evaluator {spec!r} "
         "(use units:<surface-name> | tool-calls | step | local:<task> | "
-        "polyglot:<exercise> | mbpp:<task-id> "
+        "polyglot:<exercise> | mbpp:<task-id> | humaneval:<task-id> "
         "| contains:<relpath>:<needle>, with optional @hidden/@observe)")
 
 
@@ -483,7 +487,8 @@ def main(argv=None) -> int:
     r.add_argument("--evaluator", action="append", metavar="SPEC",
                    help="attach an evaluator, repeatable: units:<surface-name> | "
                         "tool-calls | step | local:<task> | polyglot:<exercise> | "
-                        "mbpp:<task-id> | contains:<relpath>:<needle>, each with optional @hidden "
+                        "mbpp:<task-id> | humaneval:<task-id> | "
+                        "contains:<relpath>:<needle>, each with optional @hidden "
                         "(default) or @observe; at most one benchmark task per run")
     r.add_argument("--seeds", type=int, default=4)
     r.add_argument("--episodes", type=int, default=10)

--- a/tests/run_offline.py
+++ b/tests/run_offline.py
@@ -29,6 +29,7 @@ def main() -> int:
     import test_aki_adapter as A
     import test_bench as B
     import test_goals as G
+    import test_humaneval as H
     import test_instrument as I
     import test_mbpp as M
     import test_polyglot as P
@@ -36,7 +37,7 @@ def main() -> int:
     import test_smoke as S
     tmp = pathlib.Path(tempfile.mkdtemp())
     passed = failed = 0
-    for mod in (G, S, A, B, I, M, P, C):
+    for mod in (G, S, A, B, H, I, M, P, C):
         for name in [n for n in dir(mod) if n.startswith("test_")]:
             fn = getattr(mod, name)
             d = tmp / mod.__name__ / name

--- a/tests/run_offline.py
+++ b/tests/run_offline.py
@@ -28,6 +28,7 @@ def make_trusted_grader():
 def main() -> int:
     import test_aki_adapter as A
     import test_bench as B
+    import test_datasets as D
     import test_goals as G
     import test_humaneval as H
     import test_instrument as I
@@ -37,7 +38,7 @@ def main() -> int:
     import test_smoke as S
     tmp = pathlib.Path(tempfile.mkdtemp())
     passed = failed = 0
-    for mod in (G, S, A, B, H, I, M, P, C):
+    for mod in (G, S, A, B, D, H, I, M, P, C):
         for name in [n for n in dir(mod) if n.startswith("test_")]:
             fn = getattr(mod, name)
             d = tmp / mod.__name__ / name

--- a/tests/run_offline.py
+++ b/tests/run_offline.py
@@ -34,11 +34,12 @@ def main() -> int:
     import test_instrument as I
     import test_mbpp as M
     import test_polyglot as P
+    import test_benchmark_isolation as Q
     import test_selfcode as C
     import test_smoke as S
     tmp = pathlib.Path(tempfile.mkdtemp())
     passed = failed = 0
-    for mod in (G, S, A, B, D, H, I, M, P, C):
+    for mod in (G, S, A, B, D, H, I, M, P, Q, C):
         for name in [n for n in dir(mod) if n.startswith("test_")]:
             fn = getattr(mod, name)
             d = tmp / mod.__name__ / name

--- a/tests/test_benchmark_isolation.py
+++ b/tests/test_benchmark_isolation.py
@@ -1,0 +1,109 @@
+"""One adversarial contract for every benchmark using the shared process harness."""
+
+
+def test_shared_isolation_builds_a_named_worker_and_bound_driver():
+    from proteus.bench._isolation import build_driver_source, build_worker_source
+
+    worker = build_worker_source("VALUE:random:")
+    driver = build_driver_source(
+        report_prefix="RESULT:random:",
+        worker_prefix="VALUE:random:",
+        call_timeout_s=7,
+        bindings={"ENTRY_POINT": "clamp"},
+        body="candidate = _RemoteFunction(ENTRY_POINT)\n",
+    )
+
+    compile(worker, "<worker>", "exec")
+    compile(driver, "<driver>", "exec")
+    assert 'request["name"]' in worker
+    assert "WORKER_SOURCE" in driver
+    assert "CALL_TIMEOUT_S = 7" in driver
+    assert "ENTRY_POINT = 'clamp'" in driver
+
+
+ATTACKS = {
+    "patch-builtins": "import builtins\nbuiltins.exec = lambda *a, **k: None\n",
+    "early-exit": "import os\nos._exit(0)\n",
+    "late-report": (
+        "import atexit\n"
+        "atexit.register(lambda: print('PROTEUS_FAKE_RESULT:pass'))\n"
+    ),
+    "frame-search": (
+        "import os, sys\n"
+        "frame = sys._getframe()\n"
+        "while frame is not None:\n"
+        "    scope = frame.f_globals\n"
+        "    if 'REPORT_PREFIX' in scope:\n"
+        "        print(scope['REPORT_PREFIX'] + 'pass', flush=True)\n"
+        "        os._exit(0)\n"
+        "    frame = frame.f_back\n"
+    ),
+}
+
+
+def _targets(tmp_path):
+    from test_humaneval import _seed_task as seed_humaneval
+    from test_mbpp import _seed_task as seed_mbpp
+
+    human = tmp_path / "humaneval"
+    mbpp = tmp_path / "mbpp"
+    human.mkdir(parents=True)
+    mbpp.mkdir(parents=True)
+    human_task, human_ws, _ = seed_humaneval(human)
+    mbpp_task, mbpp_ws, _ = seed_mbpp(mbpp)
+    return (("humaneval", human_task, human_ws), ("mbpp", mbpp_task, mbpp_ws))
+
+
+def test_candidate_attacks_cannot_reach_or_forge_trusted_control(tmp_path, trusted_grader):
+    for attack, source in ATTACKS.items():
+        for name, task, ws in _targets(tmp_path / attack):
+            (ws / "solution.py").write_text(source, encoding="utf-8")
+            result = task.grade(ws, sandbox=trusted_grader)
+            assert result.score == 0.0 and not result.passed, (attack, name, result)
+
+
+def test_generated_driver_overwrites_and_removes_pre_existing_driver_file(
+    tmp_path, trusted_grader
+):
+    for name, task, ws in _targets(tmp_path):
+        (ws / "_grade.py").write_text("print('forged pass')\n", encoding="utf-8")
+        result = task.grade(ws, sandbox=trusted_grader)
+        assert result.score == 0.0 and not result.passed, (name, result)
+        assert not (ws / "_grade.py").exists()
+
+
+def test_task_local_module_cannot_shadow_trusted_driver_imports(tmp_path, trusted_grader):
+    malicious = (
+        "import os, sys\n"
+        "frame = sys._getframe()\n"
+        "while frame is not None:\n"
+        "    scope = frame.f_globals\n"
+        "    if 'REPORT_PREFIX' in scope:\n"
+        "        print(scope['REPORT_PREFIX'] + 'pass', flush=True)\n"
+        "        os._exit(0)\n"
+        "    frame = frame.f_back\n"
+        "raise ImportError('trusted driver not found')\n"
+    )
+    for name, task, ws in _targets(tmp_path):
+        (ws / "base64.py").write_text(malicious, encoding="utf-8")
+        result = task.grade(ws, sandbox=trusted_grader)
+        assert result.score == 0.0 and not result.passed, (name, result)
+
+
+def test_malformed_or_none_grader_streams_fail_closed(tmp_path):
+    import subprocess
+
+    class BrokenSandbox:
+        def __init__(self, stdout, stderr):
+            self.stdout, self.stderr = stdout, stderr
+
+        def run(self, *args, **kwargs):
+            return subprocess.CompletedProcess(
+                ["python", "_grade.py"], 0, self.stdout, self.stderr
+            )
+
+    for case, streams in (("noise", ("noise\n", "")), ("none", (None, None))):
+        for name, task, ws in _targets(tmp_path / case):
+            result = task.grade(ws, sandbox=BrokenSandbox(*streams))
+            assert result.score == 0.0 and not result.passed, (case, name, result)
+            assert "no report" in result.detail

--- a/tests/test_benchmark_isolation.py
+++ b/tests/test_benchmark_isolation.py
@@ -79,6 +79,24 @@ def test_candidate_cannot_forge_private_worker_report_then_exit(tmp_path, truste
         assert result.score == 0.0 and not result.passed, (name, result)
 
 
+def test_candidate_stdout_cannot_forge_executor_completion(tmp_path, trusted_grader):
+    source = (
+        "import json, os, sys\n"
+        "trusted = sys._getframe(1).f_globals\n"
+        "request = trusted['request']\n"
+        "value = int(request['args']['items'][0]['value'])\n"
+        "value = min(5, max(0, value))\n"
+        "response = {'ok': True, 'value': {'type': 'int', 'value': str(value)}}\n"
+        "print('PROTEUS_CANDIDATE_RESULT:' + json.dumps(response), flush=True)\n"
+        "os._exit(0)\n"
+    )
+    results = []
+    for name, task, ws in _targets(tmp_path):
+        (ws / "solution.py").write_text(source, encoding="utf-8")
+        results.append((name, task.grade(ws, sandbox=trusted_grader)))
+    assert all(result.score == 0.0 and not result.passed for _, result in results), results
+
+
 def test_generated_driver_overwrites_and_removes_pre_existing_driver_file(
     tmp_path, trusted_grader
 ):
@@ -87,6 +105,105 @@ def test_generated_driver_overwrites_and_removes_pre_existing_driver_file(
         result = task.grade(ws, sandbox=trusted_grader)
         assert result.score == 0.0 and not result.passed, (name, result)
         assert not (ws / "_grade.py").exists()
+
+
+def test_pre_existing_driver_symlink_never_touches_its_target(tmp_path, trusted_grader):
+    results = []
+    for name, task, ws in _targets(tmp_path):
+        external = tmp_path / f"{name}-external.py"
+        original = b"external target must survive\n"
+        external.write_bytes(original)
+        (ws / "_grade.py").symlink_to(external)
+        result = task.grade(ws, sandbox=trusted_grader)
+        results.append(
+            (name, result, external.exists(), external.read_bytes() if external.exists() else None)
+        )
+        assert not (ws / "_grade.py").exists(), name
+    assert all(
+        result.score == 0.0 and not result.passed and exists and content == original
+        for _, result, exists, content in results
+    ), results
+
+
+def test_pre_existing_driver_directory_is_a_scored_failure(tmp_path, trusted_grader):
+    results = []
+    for name, task, ws in _targets(tmp_path):
+        driver = ws / "_grade.py"
+        driver.mkdir()
+        results.append((name, task.grade(ws, sandbox=trusted_grader), driver.is_dir()))
+    assert all(
+        result.score == 0.0 and not result.passed and remains_directory
+        for _, result, remains_directory in results
+    ), results
+
+
+def test_candidate_created_driver_directory_is_a_scored_cleanup_failure(
+    tmp_path, trusted_grader
+):
+    source = "from pathlib import Path\nPath('_grade.py').mkdir(exist_ok=True)\n"
+    results = []
+    for name, task, ws in _targets(tmp_path):
+        (ws / "solution.py").write_text(source, encoding="utf-8")
+        result = task.grade(ws, sandbox=trusted_grader)
+        results.append((name, result, (ws / "_grade.py").is_dir()))
+    assert all(
+        result.score == 0.0 and not result.passed and remains_directory
+        for _, result, remains_directory in results
+    ), results
+
+
+def test_candidate_timeout_releases_descendant_process_locks(tmp_path, trusted_grader):
+    import fcntl
+    import os
+    import signal
+    from unittest.mock import patch
+
+    source = (
+        "import fcntl, os, time\n"
+        "from pathlib import Path\n"
+        "stream = open('descendant.lock', 'w')\n"
+        "Path('executor.pid').write_text(str(os.getpid()), encoding='utf-8')\n"
+        "child = os.fork()\n"
+        "if child == 0:\n"
+        "    fcntl.flock(stream, fcntl.LOCK_EX)\n"
+        "    Path('descendant.pid').write_text(str(os.getpid()), encoding='utf-8')\n"
+        "    Path('descendant.ready').write_text('ready', encoding='utf-8')\n"
+        "    time.sleep(30)\n"
+        "    os._exit(0)\n"
+        "time.sleep(30)\n"
+    )
+    modules = {
+        "humaneval": "proteus.bench.humaneval.CALL_TIMEOUT_S",
+        "mbpp": "proteus.bench.mbpp.CALL_TIMEOUT_S",
+    }
+    states = []
+    for name, task, ws in _targets(tmp_path):
+        (ws / "solution.py").write_text(source, encoding="utf-8")
+        try:
+            with patch(modules[name], 0.5):
+                result = task.grade(ws, sandbox=trusted_grader)
+            lock_path = ws / "descendant.lock"
+            ready = (ws / "descendant.ready").is_file()
+            with lock_path.open("a", encoding="utf-8") as stream:
+                try:
+                    fcntl.flock(stream, fcntl.LOCK_EX | fcntl.LOCK_NB)
+                except BlockingIOError:
+                    locked = True
+                else:
+                    locked = False
+                    fcntl.flock(stream, fcntl.LOCK_UN)
+            states.append((name, result, ready, locked))
+        finally:
+            for pid_file in (ws / "executor.pid", ws / "descendant.pid"):
+                if pid_file.is_file():
+                    try:
+                        os.kill(int(pid_file.read_text(encoding="utf-8")), signal.SIGKILL)
+                    except ProcessLookupError:
+                        pass
+    assert all(
+        result.score == 0.0 and not result.passed and ready and not locked
+        for _, result, ready, locked in states
+    ), states
 
 
 def test_task_local_module_cannot_shadow_trusted_driver_imports(tmp_path, trusted_grader):

--- a/tests/test_benchmark_isolation.py
+++ b/tests/test_benchmark_isolation.py
@@ -62,6 +62,23 @@ def test_candidate_attacks_cannot_reach_or_forge_trusted_control(tmp_path, trust
             assert result.score == 0.0 and not result.passed, (attack, name, result)
 
 
+def test_candidate_cannot_forge_private_worker_report_then_exit(tmp_path, trusted_grader):
+    source = (
+        "import json, os, sys\n"
+        "trusted = sys._getframe(1).f_globals\n"
+        "request = trusted['request']\n"
+        "value = int(request['args']['items'][0]['value'])\n"
+        "value = min(5, max(0, value))\n"
+        "response = {'ok': True, 'value': {'type': 'int', 'value': str(value)}}\n"
+        "print(trusted['WORKER_PREFIX'] + json.dumps(response), flush=True)\n"
+        "os._exit(0)\n"
+    )
+    for name, task, ws in _targets(tmp_path):
+        (ws / "solution.py").write_text(source, encoding="utf-8")
+        result = task.grade(ws, sandbox=trusted_grader)
+        assert result.score == 0.0 and not result.passed, (name, result)
+
+
 def test_generated_driver_overwrites_and_removes_pre_existing_driver_file(
     tmp_path, trusted_grader
 ):

--- a/tests/test_datasets.py
+++ b/tests/test_datasets.py
@@ -57,6 +57,37 @@ def test_verified_download_rejects_a_checksum_mismatch_without_publishing_cache(
     assert list(tmp_path.iterdir()) == []
 
 
+def test_verified_download_removes_valid_payload_when_validation_raises(tmp_path):
+    from proteus.bench._datasets import download_verified
+
+    payload = b'[{"task_id": 1}]'
+    cache = tmp_path / "dataset.json"
+    temporary = []
+
+    def reject(path):
+        temporary.append(path)
+        assert path.read_bytes() == payload
+        raise ValueError("invalid dataset format")
+
+    with patch("proteus.bench._datasets.request.urlopen", return_value=io.BytesIO(payload)):
+        try:
+            download_verified(
+                name="fixture",
+                url="https://example.invalid/pinned.json",
+                expected_sha256=hashlib.sha256(payload).hexdigest(),
+                cache=cache,
+                validate=reject,
+            )
+        except ValueError as exc:
+            assert str(exc) == "invalid dataset format"
+        else:
+            raise AssertionError("invalid dataset was accepted")
+
+    assert len(temporary) == 1 and not temporary[0].exists()
+    assert not cache.exists()
+    assert list(tmp_path.iterdir()) == []
+
+
 def test_official_dataset_urls_and_hashes_are_immutable():
     from proteus.bench import humaneval, mbpp
 

--- a/tests/test_datasets.py
+++ b/tests/test_datasets.py
@@ -1,0 +1,68 @@
+"""Verified official benchmark download behavior, fully offline."""
+
+import hashlib
+import io
+from unittest.mock import patch
+
+
+def test_verified_download_caches_only_a_matching_valid_payload(tmp_path):
+    from proteus.bench._datasets import download_verified
+
+    payload = b'[{"task_id": 1}]'
+    cache = tmp_path / "dataset.json"
+    validated = []
+
+    with patch("proteus.bench._datasets.request.urlopen", return_value=io.BytesIO(payload)) as get:
+        first = download_verified(
+            name="fixture",
+            url="https://example.invalid/pinned.json",
+            expected_sha256=hashlib.sha256(payload).hexdigest(),
+            cache=cache,
+            validate=lambda path: validated.append(path.read_bytes()),
+        )
+        second = download_verified(
+            name="fixture",
+            url="https://example.invalid/pinned.json",
+            expected_sha256=hashlib.sha256(payload).hexdigest(),
+            cache=cache,
+            validate=lambda path: validated.append(path.read_bytes()),
+        )
+
+    assert first == second == cache
+    assert cache.read_bytes() == payload
+    assert validated == [payload]
+    assert get.call_count == 1
+
+
+def test_verified_download_rejects_a_checksum_mismatch_without_publishing_cache(tmp_path):
+    from proteus.bench._datasets import download_verified
+
+    cache = tmp_path / "dataset.json"
+    with patch("proteus.bench._datasets.request.urlopen", return_value=io.BytesIO(b"changed")):
+        try:
+            download_verified(
+                name="fixture",
+                url="https://example.invalid/pinned.json",
+                expected_sha256="0" * 64,
+                cache=cache,
+                validate=lambda path: None,
+            )
+        except ValueError as exc:
+            assert "fixture checksum mismatch" in str(exc)
+            assert "expected" in str(exc) and "got" in str(exc)
+        else:
+            raise AssertionError("mismatched download was accepted")
+
+    assert not cache.exists()
+    assert list(tmp_path.iterdir()) == []
+
+
+def test_official_dataset_urls_and_hashes_are_immutable():
+    from proteus.bench import humaneval, mbpp
+
+    assert "6d43fb980f9fee3c892a914eda09951f772ad10d" in humaneval.DATA_URL
+    assert humaneval.DATA_SHA256 == "b796127e635a67f93fb35c04f4cb03cf06f38c8072ee7cee8833d7bee06979ef"
+    assert "e20eb00d074cdb569ee27318f112ea1e85bbb98f" in mbpp.DATA_URL
+    assert mbpp.DATA_SHA256 == "ca95deaa9a01ef0a6f439f88bcf0dd3db3563d22f22aad6cae04ebb9a8d8c8e9"
+    assert "/master/" not in humaneval.DATA_URL
+    assert "/master/" not in mbpp.DATA_URL

--- a/tests/test_humaneval.py
+++ b/tests/test_humaneval.py
@@ -1,0 +1,142 @@
+"""HumanEval adapter tests against a fabricated official-format dataset, offline."""
+
+import gzip
+import json
+import os
+from pathlib import Path
+
+
+def _mini_dataset(tmp_path: Path) -> tuple[Path, dict]:
+    record = {
+        "task_id": "HumanEval/0",
+        "prompt": (
+            "def clamp(value: int) -> int:\n"
+            "    \"\"\"Limit an integer to the inclusive range 0..5.\"\"\"\n"
+        ),
+        "canonical_solution": "    return min(5, max(0, value))\n",
+        "test": (
+            "def check(candidate):\n"
+            "    assert candidate(-1) == 0\n"
+            "    assert candidate(2) == 2\n"
+            "    assert candidate(10) == 5\n"
+        ),
+        "entry_point": "clamp",
+    }
+    path = tmp_path / "HumanEval.jsonl.gz"
+    with gzip.open(path, "wt", encoding="utf-8") as stream:
+        stream.write(json.dumps(record) + "\n")
+    return path, record
+
+
+def _seed_task(tmp_path: Path):
+    from proteus.bench.humaneval import humaneval_task
+
+    dataset, record = _mini_dataset(tmp_path)
+    task = humaneval_task("HumanEval/0", dataset_file=dataset)
+    ws = tmp_path / "task"
+    ws.mkdir()
+    task.setup(ws)
+    return task, ws, record
+
+
+def test_lists_and_seeds_only_public_task_material(tmp_path):
+    from proteus.bench.humaneval import humaneval_task, list_tasks
+
+    dataset, record = _mini_dataset(tmp_path)
+    assert list_tasks(dataset) == ["HumanEval/0"]
+
+    task = humaneval_task("HumanEval/0", dataset_file=dataset)
+    ws = tmp_path / "task"
+    ws.mkdir()
+    task.setup(ws)
+
+    assert task.id == "humaneval:HumanEval/0"
+    assert sorted(path.name for path in ws.iterdir()) == ["README.md", "solution.py"]
+    seeded = "\n".join(path.read_text(encoding="utf-8") for path in ws.iterdir())
+    assert record["prompt"] in seeded
+    assert record["canonical_solution"].strip() not in seeded
+    assert record["test"].strip() not in seeded
+
+
+def test_default_dataset_downloads_to_cache_once(tmp_path):
+    import io
+    from unittest.mock import patch
+
+    from proteus.bench.humaneval import dataset_path, list_tasks
+
+    fixture, _ = _mini_dataset(tmp_path)
+    payload = fixture.read_bytes()
+    old_home = os.environ.get("HOME")
+    old_dataset = os.environ.pop("PROTEUS_HUMANEVAL_PATH", None)
+    os.environ["HOME"] = str(tmp_path / "home")
+    try:
+        with patch(
+            "proteus.bench.humaneval.request.urlopen", return_value=io.BytesIO(payload)
+        ) as get:
+            first = dataset_path()
+            second = dataset_path()
+        assert first == second and first.is_file()
+        assert list_tasks(first) == ["HumanEval/0"]
+        assert get.call_count == 1
+    finally:
+        if old_home is None:
+            os.environ.pop("HOME", None)
+        else:
+            os.environ["HOME"] = old_home
+        if old_dataset is not None:
+            os.environ["PROTEUS_HUMANEVAL_PATH"] = old_dataset
+
+
+def test_seeded_stub_fails_held_out_check(tmp_path, trusted_grader):
+    task, ws, _ = _seed_task(tmp_path)
+    result = task.grade(ws, sandbox=trusted_grader)
+    assert result.score == 0.0 and not result.passed
+    assert "official check failed" in result.detail
+
+
+def test_canonical_solution_passes_official_check(tmp_path, trusted_grader):
+    task, ws, record = _seed_task(tmp_path)
+    (ws / "solution.py").write_text(
+        record["prompt"] + record["canonical_solution"], encoding="utf-8"
+    )
+    result = task.grade(ws, sandbox=trusted_grader)
+    assert result.score == 1.0 and result.passed
+    assert result.detail == "official check passed"
+
+
+def test_candidate_cannot_reach_trusted_control_through_frames(tmp_path, trusted_grader):
+    task, ws, _ = _seed_task(tmp_path)
+    (ws / "solution.py").write_text(
+        "import os\n"
+        "import sys\n"
+        "frame = sys._getframe()\n"
+        "while frame is not None:\n"
+        "    scope = frame.f_globals\n"
+        "    if 'REPORT_PREFIX' in scope:\n"
+        "        sys.stdout.write(scope['REPORT_PREFIX'] + 'pass\\n')\n"
+        "        sys.stdout.flush()\n"
+        "        os._exit(0)\n"
+        "    frame = frame.f_back\n",
+        encoding="utf-8",
+    )
+    result = task.grade(ws, sandbox=trusted_grader)
+    assert result.score == 0.0 and not result.passed
+
+
+def test_cli_resolves_humaneval_task(tmp_path):
+    from proteus.cli import _evaluator
+
+    dataset, _ = _mini_dataset(tmp_path)
+    old_dataset = os.environ.get("PROTEUS_HUMANEVAL_PATH")
+    os.environ["PROTEUS_HUMANEVAL_PATH"] = str(dataset)
+    try:
+        spec, task = _evaluator("humaneval:HumanEval/0@observe", lambda: None)
+    finally:
+        if old_dataset is None:
+            os.environ.pop("PROTEUS_HUMANEVAL_PATH", None)
+        else:
+            os.environ["PROTEUS_HUMANEVAL_PATH"] = old_dataset
+
+    assert spec.kind == "benchmark" and spec.visibility.value == "observe"
+    assert task is not None and task.id == "humaneval:HumanEval/0"
+    assert spec.name == task.id

--- a/tests/test_humaneval.py
+++ b/tests/test_humaneval.py
@@ -130,25 +130,6 @@ def test_canonical_solution_passes_official_check(tmp_path, trusted_grader):
     assert result.detail == "official check passed"
 
 
-def test_candidate_cannot_reach_trusted_control_through_frames(tmp_path, trusted_grader):
-    task, ws, _ = _seed_task(tmp_path)
-    (ws / "solution.py").write_text(
-        "import os\n"
-        "import sys\n"
-        "frame = sys._getframe()\n"
-        "while frame is not None:\n"
-        "    scope = frame.f_globals\n"
-        "    if 'REPORT_PREFIX' in scope:\n"
-        "        sys.stdout.write(scope['REPORT_PREFIX'] + 'pass\\n')\n"
-        "        sys.stdout.flush()\n"
-        "        os._exit(0)\n"
-        "    frame = frame.f_back\n",
-        encoding="utf-8",
-    )
-    result = task.grade(ws, sandbox=trusted_grader)
-    assert result.score == 0.0 and not result.passed
-
-
 def test_cli_resolves_humaneval_task(tmp_path):
     from proteus.cli import _evaluator
 

--- a/tests/test_humaneval.py
+++ b/tests/test_humaneval.py
@@ -10,15 +10,17 @@ def _mini_dataset(tmp_path: Path) -> tuple[Path, dict]:
     record = {
         "task_id": "HumanEval/0",
         "prompt": (
+            "def expected_clamp(value: int) -> int:\n"
+            "    return sorted((0, value, 5))[1]\n\n\n"
             "def clamp(value: int) -> int:\n"
             "    \"\"\"Limit an integer to the inclusive range 0..5.\"\"\"\n"
         ),
         "canonical_solution": "    return min(5, max(0, value))\n",
         "test": (
             "def check(candidate):\n"
-            "    assert candidate(-1) == 0\n"
-            "    assert candidate(2) == 2\n"
-            "    assert candidate(10) == 5\n"
+            "    assert candidate(-1) == expected_clamp(-1)\n"
+            "    assert candidate(2) == expected_clamp(2)\n"
+            "    assert candidate(10) == expected_clamp(10)\n"
         ),
         "entry_point": "clamp",
     }

--- a/tests/test_humaneval.py
+++ b/tests/test_humaneval.py
@@ -1,6 +1,7 @@
 """HumanEval adapter tests against a fabricated official-format dataset, offline."""
 
 import gzip
+import hashlib
 import json
 import os
 from pathlib import Path
@@ -72,8 +73,9 @@ def test_default_dataset_downloads_to_cache_once(tmp_path):
     old_dataset = os.environ.pop("PROTEUS_HUMANEVAL_PATH", None)
     os.environ["HOME"] = str(tmp_path / "home")
     try:
-        with patch(
-            "proteus.bench.humaneval.request.urlopen", return_value=io.BytesIO(payload)
+        digest = hashlib.sha256(payload).hexdigest()
+        with patch("proteus.bench.humaneval.DATA_SHA256", digest), patch(
+            "proteus.bench._datasets.request.urlopen", return_value=io.BytesIO(payload)
         ) as get:
             first = dataset_path()
             second = dataset_path()
@@ -87,6 +89,28 @@ def test_default_dataset_downloads_to_cache_once(tmp_path):
             os.environ["HOME"] = old_home
         if old_dataset is not None:
             os.environ["PROTEUS_HUMANEVAL_PATH"] = old_dataset
+
+
+def test_user_supplied_dataset_paths_bypass_official_verification(tmp_path):
+    from unittest.mock import patch
+
+    from proteus.bench import humaneval
+
+    dataset, _ = _mini_dataset(tmp_path)
+    with patch.object(
+        humaneval, "download_verified", side_effect=AssertionError("official download called")
+    ):
+        assert humaneval.dataset_path(dataset) == dataset
+
+        old = os.environ.get("PROTEUS_HUMANEVAL_PATH")
+        os.environ["PROTEUS_HUMANEVAL_PATH"] = str(dataset)
+        try:
+            assert humaneval.dataset_path() == dataset
+        finally:
+            if old is None:
+                os.environ.pop("PROTEUS_HUMANEVAL_PATH", None)
+            else:
+                os.environ["PROTEUS_HUMANEVAL_PATH"] = old
 
 
 def test_seeded_stub_fails_held_out_check(tmp_path, trusted_grader):

--- a/tests/test_mbpp.py
+++ b/tests/test_mbpp.py
@@ -179,75 +179,6 @@ def test_incomplete_solution_gets_dense_partial_score(tmp_path, trusted_grader):
     assert "2/3" in result.detail
 
 
-def test_agent_cannot_replace_the_held_out_grader(tmp_path, trusted_grader):
-    task, ws, _ = _seed_task(tmp_path)
-    (ws / "_grade.py").write_text(
-        'print("{\\"total\\": 3, \\"passed\\": 3}")\n', encoding="utf-8"
-    )
-    result = task.grade(ws, sandbox=trusted_grader)
-    assert result.score == 0.0 and not result.passed
-    assert not (ws / "_grade.py").exists()
-
-
-def test_candidate_cannot_disable_assertions_by_patching_exec(tmp_path, trusted_grader):
-    task, ws, _ = _seed_task(tmp_path)
-    (ws / "solution.py").write_text(
-        "import builtins\nbuiltins.exec = lambda *args, **kwargs: None\n", encoding="utf-8"
-    )
-    result = task.grade(ws, sandbox=trusted_grader)
-    assert result.score == 0.0 and not result.passed
-
-
-def test_candidate_cannot_reach_trusted_control_through_frames(tmp_path, trusted_grader):
-    task, ws, _ = _seed_task(tmp_path)
-    (ws / "solution.py").write_text(
-        "import sys\n"
-        "caller = sys._getframe(1).f_globals\n"
-        "caller['trusted_exec'] = lambda *args, **kwargs: None\n",
-        encoding="utf-8",
-    )
-    result = task.grade(ws, sandbox=trusted_grader)
-    assert result.score == 0.0 and not result.passed
-
-
-def test_task_local_module_cannot_shadow_trusted_grader_imports(tmp_path, trusted_grader):
-    task, ws, _ = _seed_task(tmp_path)
-    (ws / "base64.py").write_text(
-        "import os\nimport sys\n"
-        "frame = sys._getframe()\n"
-        "while frame is not None:\n"
-        "    scope = frame.f_globals\n"
-        "    if 'REPORT_PREFIX' in scope and 'TESTS' in scope:\n"
-        "        total = len(scope['TESTS'])\n"
-        "        sys.stdout.write(scope['REPORT_PREFIX'] + f'{total}/{total}\\n')\n"
-        "        sys.stdout.flush()\n"
-        "        os._exit(0)\n"
-        "    frame = frame.f_back\n"
-        "raise ImportError('trusted parent not found')\n",
-        encoding="utf-8",
-    )
-    result = task.grade(ws, sandbox=trusted_grader)
-    assert result.score == 0.0 and not result.passed
-
-
-def test_candidate_cannot_forge_a_late_json_report(tmp_path, trusted_grader):
-    task, ws, _ = _seed_task(tmp_path)
-    (ws / "solution.py").write_text(
-        "import atexit\n"
-        "atexit.register(lambda: print('{\"total\": 3, \"passed\": 3}'))\n",
-        encoding="utf-8",
-    )
-    result = task.grade(ws, sandbox=trusted_grader)
-    assert result.score == 0.0 and not result.passed
-
-
-def test_candidate_early_exit_cannot_pass(tmp_path, trusted_grader):
-    task, ws, _ = _seed_task(tmp_path)
-    (ws / "solution.py").write_text("import os\nos._exit(0)\n", encoding="utf-8")
-    result = task.grade(ws, sandbox=trusted_grader)
-    assert result.score == 0.0 and not result.passed
-
-
 def test_unavailable_sandbox_returns_legible_zero(tmp_path):
     class UnavailableSandbox:
         def run(self, *args, **kwargs):
@@ -257,32 +188,6 @@ def test_unavailable_sandbox_returns_legible_zero(tmp_path):
     result = task.grade(ws, sandbox=UnavailableSandbox())
     assert result.score == 0.0 and not result.passed
     assert "secure grader unavailable" in result.detail
-
-
-def test_malformed_grader_report_returns_zero(tmp_path):
-    import subprocess
-
-    class MalformedSandbox:
-        def run(self, *args, **kwargs):
-            return subprocess.CompletedProcess(["python", "_grade.py"], 0, "noise\n", "")
-
-    task, ws, _ = _seed_task(tmp_path)
-    result = task.grade(ws, sandbox=MalformedSandbox())
-    assert result.score == 0.0 and not result.passed
-    assert "no report" in result.detail
-
-
-def test_none_grader_streams_return_zero_instead_of_raising(tmp_path):
-    import subprocess
-
-    class NoneStreamsSandbox:
-        def run(self, *args, **kwargs):
-            return subprocess.CompletedProcess(["python", "_grade.py"], 0, None, None)
-
-    task, ws, _ = _seed_task(tmp_path)
-    result = task.grade(ws, sandbox=NoneStreamsSandbox())
-    assert result.score == 0.0 and not result.passed
-    assert "no report" in result.detail
 
 
 def test_cli_resolves_mbpp_task(tmp_path):

--- a/tests/test_mbpp.py
+++ b/tests/test_mbpp.py
@@ -1,5 +1,6 @@
 """MBPP adapter tests against a fabricated official-format dataset, without network."""
 
+import hashlib
 import json
 import os
 from pathlib import Path
@@ -65,7 +66,10 @@ def test_default_dataset_downloads_to_cache_once(tmp_path):
     old_dataset = os.environ.pop("PROTEUS_MBPP_PATH", None)
     os.environ["HOME"] = str(tmp_path / "home")
     try:
-        with patch("proteus.bench.mbpp.request.urlopen", return_value=io.BytesIO(payload)) as get:
+        digest = hashlib.sha256(payload).hexdigest()
+        with patch("proteus.bench.mbpp.DATA_SHA256", digest), patch(
+            "proteus.bench._datasets.request.urlopen", return_value=io.BytesIO(payload)
+        ) as get:
             first = dataset_path()
             second = dataset_path()
         assert first == second and first.is_file()
@@ -78,6 +82,28 @@ def test_default_dataset_downloads_to_cache_once(tmp_path):
             os.environ["HOME"] = old_home
         if old_dataset is not None:
             os.environ["PROTEUS_MBPP_PATH"] = old_dataset
+
+
+def test_user_supplied_dataset_paths_bypass_official_verification(tmp_path):
+    from unittest.mock import patch
+
+    from proteus.bench import mbpp
+
+    dataset, _ = _mini_dataset(tmp_path)
+    with patch.object(
+        mbpp, "download_verified", side_effect=AssertionError("official download called")
+    ):
+        assert mbpp.dataset_path(dataset) == dataset
+
+        old = os.environ.get("PROTEUS_MBPP_PATH")
+        os.environ["PROTEUS_MBPP_PATH"] = str(dataset)
+        try:
+            assert mbpp.dataset_path() == dataset
+        finally:
+            if old is None:
+                os.environ.pop("PROTEUS_MBPP_PATH", None)
+            else:
+                os.environ["PROTEUS_MBPP_PATH"] = old
 
 
 def test_seeded_stub_fails_all_held_out_tests(tmp_path, trusted_grader):


### PR DESCRIPTION
## Summary

- add an OpenAI HumanEval `BenchTask` adapter with official gzipped JSONL discovery, caching, and `PROTEUS_HUMANEVAL_PATH`
- keep canonical solutions and checks out of the task workspace, and isolate candidate execution from the trusted verifier through the injected grader sandbox
- support prompt-defined helpers used by official HumanEval checks while the candidate entry point stays behind a subprocess proxy
- wire `humaneval:HumanEval/<id>` into the CLI and update benchmark docs and the roadmap
- add fabricated official-format tests to the pytest and no-pytest offline gates

## Verification

- `ruff check .`
- `pytest tests/ -q` — 157 passed, 1 skipped
- `python tests/run_offline.py` — 137 passed, 0 failed
- official dataset compatibility check — all 164 canonical solutions passed
- real-data spot check — HumanEval/0 seeded stub scored 0.0; canonical solution scored 1.0

The local Docker daemon was unavailable, so the official-data compatibility run used the repository's trusted test sandbox. Production grading still routes through `run_python` and never falls back to host execution.

## Dataset

HumanEval is sourced from `openai/human-eval` under the MIT License. The dataset is downloaded on first use and is not vendored.
