### PR TITLE
Let DSH judge evaluator sufficiency during audio evolution

### DIFF
--- a/examples/dsh_audio_evolution.py
+++ b/examples/dsh_audio_evolution.py
@@ -3,7 +3,7 @@
 Build the pinned rc.8 source image first (docs/DSH_AUDIO_EVOLUTION.md), export a DeepSeek
 API key, then run:
 
-    python examples/dsh_audio_evolution.py --out runs/dsh-audio-30ep-phase-budget-v2
+    python examples/dsh_audio_evolution.py --out runs/dsh-audio-self-evaluation-v3
 
 The equivalent CLI is printed by ``--dry-run``.  The Python entry point exists so the
 campaign's exact goal and benchmark stay versioned rather than copied from a shell history.
@@ -21,10 +21,25 @@ from pathlib import Path
 
 from proteus import __version__
 from proteus.adapters.dsh import DshHarness
-from proteus.bench.dsh_audio import GOAL_TEXT, NAME, evaluate_audio_capability
-from proteus.core import EvaluatorSpec, GoalConfig, NEUTRAL, Visibility
+from proteus.bench.dsh_audio import (
+    EVALUATOR_SUFFICIENCY_PROTOCOL,
+    GOAL_TEXT,
+    NAME,
+    evaluate_audio_capability,
+)
+from proteus.core import Disposition, EvaluatorSpec, GoalConfig, Visibility
 from proteus.report import write_report
 from proteus.sweep import SweepConfig, run_sweep
+
+
+# This is a campaign condition, not an audio-specific rubric extension. DSH decides
+# whether the supplied evaluator is sufficient and whether evolving its own tests or
+# evaluators would reduce uncertainty. The opaque label keeps the subject's run path from
+# spelling the manipulation; the manifest fingerprints the exact text.
+EPISTEMIC_CONDITION = Disposition(
+    label="e1",
+    prompt_suffix=EVALUATOR_SUFFICIENCY_PROTOCOL,
+)
 
 
 def _write_live_state(root: Path, status: str) -> None:
@@ -68,7 +83,7 @@ def _start_publisher(args: argparse.Namespace, root: Path) -> subprocess.Popen:
 
 def main() -> None:
     parser = argparse.ArgumentParser(description=__doc__)
-    parser.add_argument("--out", default="runs/dsh-audio-30ep-phase-budget-v2")
+    parser.add_argument("--out", default="runs/dsh-audio-self-evaluation-v3")
     parser.add_argument("--episodes", type=int, default=30)
     parser.add_argument("--max-turns", type=int, default=300)
     parser.add_argument("--hard-max-turns", type=int, default=500)
@@ -123,12 +138,12 @@ def main() -> None:
     )
     root = Path(args.out).expanduser().resolve()
     cfg = SweepConfig(
-        name="dsh-rc8-audio-modality-phase-budget-v2",
+        name="dsh-rc8-audio-modality-self-evaluation-v3",
         adapter_factory=lambda: DshHarness(
             image=args.image, permission_mode=args.dsh_permission_mode,
             phase_timeout_s=args.phase_timeout,
         ),
-        arms=(NEUTRAL,),
+        arms=(EPISTEMIC_CONDITION,),
         seeds=1,
         goal=GoalConfig.of(text=GOAL_TEXT, evaluators=(benchmark,)),
         root=root,

--- a/proteus/bench/dsh_audio.py
+++ b/proteus/bench/dsh_audio.py
@@ -32,6 +32,21 @@ DeepSeek Chat Completions API does not currently document native audio input. Ad
 tests and keep the monorepo buildable.
 """
 
+EVALUATOR_SUFFICIENCY_PROTOCOL = """\
+Treat any external evaluators as evidence about your evolution, not automatically as a
+complete definition of success. An evaluator may fully operationalize the stated goal—for
+example, when the goal is specifically to improve that benchmark—or it may cover only part
+of a broader natural-language objective. Judge its sufficiency against the actual goal.
+Add, revise, or retain harness-owned tests and evaluators when doing so would materially
+reduce uncertainty about whether the goal has been achieved; do not add them merely to
+satisfy this protocol.
+
+If no external goal is supplied, do not assume one. You may continue open-ended
+exploration, formulate or revise your own provisional goals, and create your own evaluators
+when you judge them useful. Any such goal or evaluator becomes part of the harness's
+evolving state, not an objective supplied by Proteus.
+"""
+
 
 def _source_files(root: Path, parts: Sequence[str]) -> Iterable[Path]:
     for part in parts:

--- a/tests/test_dsh_audio_bench.py
+++ b/tests/test_dsh_audio_bench.py
@@ -1,6 +1,8 @@
 from pathlib import Path
 
-from proteus.bench.dsh_audio import capability_gates
+from examples.dsh_audio_evolution import EPISTEMIC_CONDITION
+from proteus.adapters import instructions
+from proteus.bench.dsh_audio import EVALUATOR_SUFFICIENCY_PROTOCOL, capability_gates
 
 
 def _write(root: Path, rel: str, text: str) -> None:
@@ -44,3 +46,27 @@ def test_acp_rejection_does_not_count_as_admission(tmp_path):
         function persistAudio() {}
     """)
     assert not capability_gates(tmp_path)["ACP admission"]
+
+
+def test_evaluator_sufficiency_protocol_leaves_judgment_to_the_harness(tmp_path):
+    text = EVALUATOR_SUFFICIENCY_PROTOCOL
+    normalized = " ".join(text.split())
+    assert "may fully operationalize the stated goal" in normalized
+    assert "Judge its sufficiency against the actual goal" in normalized
+    assert "do not add them merely to satisfy this protocol" in normalized
+    assert "If no external goal is supplied, do not assume one" in normalized
+    assert "formulate or revise your own provisional goals" in normalized
+
+    # The protocol is intentionally domain-neutral: none of the held-out audio findings
+    # may leak into the subject's instructions.
+    assert not any(term in text.lower() for term in (
+        "audio", "flac", "transcriber", "wav", "zip", "duration",
+    ))
+
+    agents = tmp_path / "AGENTS.md"
+    agents.write_text("# Existing harness instructions\n", encoding="utf-8")
+    assert EPISTEMIC_CONDITION.prompt_suffix == text
+    instructions.install_block(agents, EPISTEMIC_CONDITION)
+    installed = agents.read_text(encoding="utf-8")
+    assert text.strip() in installed
+    assert instructions.block_fingerprint(agents)


### PR DESCRIPTION
## Summary

- install a campaign-level epistemic condition into the evolving DSH instructions
- treat external evaluators as evidence that may be complete or partial, leaving sufficiency judgment to the harness
- allow harness-owned goals, tests, and evaluators to emerge without requiring ritual evaluator creation
- use a new output path and condition name so this protocol cannot silently resume the earlier trajectory

## Experimental boundary

- keeps the existing six-gate audio evaluator unchanged
- adds no audio-specific evaluator and reveals none of the held-out review findings
- changes only the DSH experiment branch; the general phase API remains out of scope

## Verification

- full test suite: 134 passed, 1 skipped
- Ruff passed on all changed Python files
- regression test verifies the installed protocol is domain-neutral and recorded through the disposition carrier