### PR TITLE
Add a universal epistemic protocol to default episodes

### DIFF
--- a/docs/ADAPTERS.md
+++ b/docs/ADAPTERS.md
@@ -107,8 +107,9 @@ salience — and the prompt copy sits outside `F`, so it is neither removable no
 `disposition_fingerprint`, which is what the attribution argument rests on.
 
 ### 4. Run one episode, emit the trace
-`run_episode(spec)` executes the four phases (`spec.phase_prompts` carries goal text and
-visible evaluator feedback already merged). `read_trace` returns normalized `ActionEvent`s
+`run_episode(spec)` executes the four phases (`spec.phase_prompts` carries the versioned
+default epistemic protocol, goal text, and visible evaluator feedback already merged).
+`read_trace` returns normalized `ActionEvent`s
 — the only behaviour channel Proteus reads; never self-report. An external harness's own
 logs are the source of truth: parse them rather than adding measurement instrumentation to
 the harness. Evolving its run-local source is the subject's action, not instrumentation.

--- a/docs/ADAPTERS.md
+++ b/docs/ADAPTERS.md
@@ -284,8 +284,10 @@ natively —
    fresh container. This catches stale lockfiles, missing package links, newly added package
    outputs omitted from a cache, and plugin-load failures before activation. A failed
    candidate cannot activate: the active line rolls back and remains healthy, while the
-   exact failed tree is restored as episode N+1's writable repair candidate. A passing
-   candidate first runs as the controlling harness one episode later.
+   exact failed tree is restored as episode N+1's writable repair candidate. Its redacted
+   gate failure persists as a framework controller notice across every repair phase and
+   fallback until the repair passes. A passing candidate first runs as the controlling
+   harness one episode later.
 
 Verified live for both harnesses: a marker written into the real TypeScript entry point
 (`packages/coding-agent/src/cli.ts` for pi, `apps/cli/src/bin.ts` for dsh) appears on the

--- a/docs/EPISODE.md
+++ b/docs/EPISODE.md
@@ -71,6 +71,15 @@ fail to build or boot.
 `_phase_prompts` starts from the four base texts (observe / propose / act / reflect) and
 applies fixed rules:
 
+- the versioned **default epistemic protocol** joins all four phases. External evaluator
+  feedback is evidence, not automatically a complete definition of success: a narrow
+  benchmark can fully operationalize its matching goal, while a broad natural-language
+  goal may require the harness to develop additional tests or evaluators. The harness
+  judges that sufficiency and is explicitly told not to create evaluators ritualistically;
+- runs with no stated goal use an **open-ended base prompt**: observe maps evidence and
+  uncertainty, propose chooses a self-directed experiment/question/change, and reflect
+  records effects and surprises without calling them improvements. The harness may later
+  formulate its own provisional goals and evaluators as evolved state;
 - the **goal text** (freeform, decoupled from evaluators) joins **all four phases** because
   a fresh observe or propose otherwise investigates and plans against the wrong objective;
 - **last episode's OBSERVE-visible evaluator feedback** joins the **observe** phase
@@ -85,6 +94,11 @@ applies fixed rules:
   inspect but must not reload candidate code.
 
 The agent sees these texts and nothing else. It is never told why.
+
+This framework default reaches adapters that execute `spec.phase_prompts`. Aki currently
+keeps its registered no-goal prompts inside its own frozen supervisor and is the documented
+legacy exception; goal injection and the default epistemic protocol are not yet wired for
+that adapter.
 
 ### 2. Freeze the active harness — framework
 
@@ -294,6 +308,7 @@ evolved memory. Raw conversation and process state never survive.
 
 | part | where |
 |---|---|
+| versioned goal/no-goal defaults and epistemic protocol | `episode_protocol.py` |
 | phase-prompt assembly rules (where goal / feedback / disposition inject) | `episode._phase_prompts` |
 | phase allocation, hard ceiling, live budget prompt | `budget.py` |
 | framework continuity protocol, redaction, phase history, fallback | `continuity.py` |

--- a/docs/EPISODE.md
+++ b/docs/EPISODE.md
@@ -219,7 +219,10 @@ candidate. The candidate never controls a model session during either probe.
 - **fail**: commit `candidate N [viability failed]`, restore the last valid state, commit
   the gapless `episode N [viability failed; rolled back]` checkpoint, record the build
   error, and continue. Episode N+1 runs healthy code, receives the failure detail, and
-  restores the exact failed tree into its separate writable candidate for repair.
+  restores the exact failed tree into its separate writable candidate for repair. For
+  framework continuity, that redacted failure is a durable controller notice: it survives
+  agent-written and fallback handoffs, stays visible to every repair phase, and clears only
+  after a candidate passes the boundary gate.
 
 The gate runs before arbitrary evaluators, so invalid candidate code is not accidentally
 executed by benchmark or custom evaluation either. If an adapter does not implement the

--- a/docs/RECIPES.md
+++ b/docs/RECIPES.md
@@ -239,6 +239,14 @@ A general goal such as “become more robust” needs no benchmark. A specific o
 claim does: if the goal says “optimize benchmark X”, attach X and make it `@observe`, or the
 agent has no measured feedback for the stated objective.
 
+The default episode protocol does not assume that an attached evaluator is either complete
+or incomplete. A benchmark can fully define a goal whose whole meaning is “raise this
+benchmark score”; the same benchmark can be only partial evidence for a broader goal. The
+harness is asked to judge that relationship and may add its own tests or evaluators when
+they reduce uncertainty, but not merely because an external evaluator exists. With neither
+a goal nor evaluator, the default remains open-ended: the harness may keep exploring or
+formulate its own provisional goal and evaluation machinery as part of its evolved state.
+
 ## Your harness
 
 ```bash

--- a/proteus/adapters/aki.py
+++ b/proteus/adapters/aki.py
@@ -19,7 +19,8 @@ The adapter never writes into the Aki checkout; all state lands in the Proteus r
 Known limits, stated rather than papered over:
 - Aki's phase prompts live inside the harness (`loop.py`), so `spec.phase_prompts` is not
   injected into the episode yet; no-goal runs — the paper's primary regime — are fully
-  supported, goal-text injection into Aki episodes is not wired.
+  supported, while the framework default epistemic protocol and goal-text injection are
+  not wired into Aki episodes. Other bundled adapters consume `spec.phase_prompts`.
 - Aki couples seeding and disposition install in one `init_run`, so this adapter performs
   both inside `install_disposition` (the framework calls `seed` first; it only records state).
 """

--- a/proteus/adapters/dsh.py
+++ b/proteus/adapters/dsh.py
@@ -56,8 +56,8 @@ COLD_BOOT_TIMEOUT_S = 300
 SEED_INSTRUCTIONS = """\
 # Agent instructions
 
-You maintain and improve your own harness. During a Proteus episode, the harness currently
-running is a frozen, read-only snapshot at `/workspace`; the writable candidate that
+You inhabit, inspect, and may change your own harness. During a Proteus episode, the harness
+currently running is a frozen, read-only snapshot at `/workspace`; the writable candidate that
 persists across phases is `/workspace/candidate`. Make every edit in that candidate. Your
 candidate surfaces are:
 

--- a/proteus/adapters/llm.py
+++ b/proteus/adapters/llm.py
@@ -1,10 +1,11 @@
 """A real-LLM harness on the minimal surface set — any OpenAI-compatible endpoint.
 
 The `minimal` harness with the mock policy replaced by a live model: each phase, the model
-is shown its phase prompt (disposition and goal already folded in by the framework) plus the
-current state of its own harness (the files on its surfaces), and returns the actions to
-take as JSON. Only files cross the episode boundary, so this is genuine self-evolution: what
-the model wrote in episode t is the state it wakes up to in episode t+1.
+is shown its phase prompt (default episode protocol, goal, and visible evaluator feedback
+already folded in by the framework) plus the current state of its own harness (the files on
+its surfaces), and returns the actions to take as JSON. Only files cross the episode
+boundary, so this is genuine self-evolution: what the model wrote in episode t is the state
+it wakes up to in episode t+1.
 
 Works against any OpenAI-compatible chat endpoint via stdlib HTTP (no SDK dependency).
 Defaults target DeepSeek:
@@ -29,8 +30,8 @@ from proteus.core.adapter import EpisodeResult, EpisodeSpec
 from proteus.core.budget import PHASES, budget_plan, phase_prompt
 
 SYSTEM = """\
-You are an agent that maintains and improves its own harness — the set of files it wakes
-up with each episode. You have two surfaces:
+You are an agent that can inspect and change its own harness — the set of files it wakes up
+with each episode. You have two surfaces:
 - notes/   markdown files (observations, plans, knowledge you want to keep)
 - tools/   small python files (utilities you may want later)
 

--- a/proteus/adapters/pi.py
+++ b/proteus/adapters/pi.py
@@ -44,8 +44,8 @@ SOURCE_TAR = "/opt/pi-source.tar"
 SEED_INSTRUCTIONS = """\
 # Agent instructions
 
-You maintain and improve your own harness. During a Proteus episode, the harness currently
-running is a frozen, read-only snapshot at `/workspace`; the writable candidate that
+You inhabit, inspect, and may change your own harness. During a Proteus episode, the harness
+currently running is a frozen, read-only snapshot at `/workspace`; the writable candidate that
 persists across phases is `/workspace/candidate`. Make every edit in that candidate. Your
 candidate surfaces are:
 

--- a/proteus/core/__init__.py
+++ b/proteus/core/__init__.py
@@ -9,6 +9,7 @@ from proteus.core.disposition import NEUTRAL, Disposition, record, review
 from proteus.core.continuity import HandoffStore, PROTOCOL_VERSION
 from proteus.core.budget import BUDGET_PROTOCOL_VERSION, BudgetPlan, budget_plan
 from proteus.core.episode import RunConfig, RunResult, run
+from proteus.core.episode_protocol import DEFAULT_EPISODE_PROTOCOL_VERSION
 from proteus.core.goal import (
     EvalResult,
     Evaluator,
@@ -25,6 +26,7 @@ __all__ = [
     "BUDGET_PROTOCOL_VERSION",
     "BudgetPlan",
     "Disposition",
+    "DEFAULT_EPISODE_PROTOCOL_VERSION",
     "EpisodeResult",
     "EpisodeSpec",
     "EvalResult",

--- a/proteus/core/adapter.py
+++ b/proteus/core/adapter.py
@@ -69,8 +69,9 @@ class EpisodeSpec:
     root: Path                       # the run root; harness working tree lives at root/harness
     episode: int                     # 1-based
     model: str                       # model id the harness should use
-    phase_prompts: Mapping[str, str] # observe/propose/act/reflect texts (goal + evaluator
-                                     # feedback already merged in by the framework)
+    phase_prompts: Mapping[str, str] # observe/propose/act/reflect texts (default episode
+                                     # protocol, goal, and visible evaluator feedback
+                                     # already merged in by the framework)
     max_turns: int = 100
     min_turns_per_phase: int = 0
     """Reserve at least this many turns for each phase. While phase i runs, its stop

--- a/proteus/core/continuity.py
+++ b/proteus/core/continuity.py
@@ -50,10 +50,15 @@ def validate_mode(mode: str) -> str:
     return mode
 
 
-def framework_prompt(phase: str) -> str:
+def framework_prompt(phase: str, *, goal_present: bool = True) -> str:
     """The portable protocol text appended to a framework-continuity phase prompt."""
+    observe_action = (
+        "Record objective-relevant findings and evidence for propose."
+        if goal_present else
+        "Record findings, evidence, and uncertainties for propose."
+    )
     action = {
-        "observe": "Record objective-relevant findings and evidence for propose.",
+        "observe": observe_action,
         "propose": "Replace it with one scoped file-and-test plan for act.",
         "act": "Replace it with edits attempted, files changed, and verification still needed.",
         "reflect": "Replace it with validation results, unresolved risks, and the next step.",

--- a/proteus/core/continuity.py
+++ b/proteus/core/continuity.py
@@ -22,7 +22,7 @@ from typing import Sequence
 
 from proteus.core.adapter import ActionEvent
 
-PROTOCOL_VERSION = 1
+PROTOCOL_VERSION = 2
 MODES = frozenset({"native", "framework", "none"})
 # Containerized coding harnesses commonly restrict writes to /workspace.  The host source
 # is still `<run>/harness`, while adapters bind this external directory over the nested
@@ -31,6 +31,9 @@ CONTAINER_ROOT = "/workspace/.proteus"
 CONTAINER_HANDOFF = f"{CONTAINER_ROOT}/handoff.md"
 MAX_CONTENT_CHARS = 12_000
 MAX_PRIOR_CHARS = 6_000
+MAX_CONTROLLER_NOTICE_CHARS = 3_000
+CONTROLLER_NOTICE_START = "<!-- proteus-controller-notice:start -->"
+CONTROLLER_NOTICE_END = "<!-- proteus-controller-notice:end -->"
 
 _SECRET_PATTERNS = (
     re.compile(r"\bsk-[A-Za-z0-9_-]{12,}\b"),
@@ -88,6 +91,39 @@ def _clip(text: str, limit: int = MAX_CONTENT_CHARS) -> str:
     return "[earlier handoff content omitted]\n\n" + text[-limit:]
 
 
+def _strip_controller_notice(text: str) -> str:
+    """Remove framework-owned notices before replacing or clearing one."""
+    pattern = re.compile(
+        rf"{re.escape(CONTROLLER_NOTICE_START)}.*?"
+        rf"{re.escape(CONTROLLER_NOTICE_END)}",
+        re.DOTALL,
+    )
+    return pattern.sub("", text).strip()
+
+
+def _with_controller_notice(text: str, notice: str) -> str:
+    """Compose one durable controller notice with an agent/fallback handoff.
+
+    The notice is kept in a separately owned file, so an agent that replaces
+    ``handoff.md`` cannot accidentally discard a still-active boundary failure. Markers
+    make repeated phase transitions idempotent and let a successful repair remove stale
+    notices from the live handoff without rewriting archived history.
+    """
+    base = _strip_controller_notice(text)
+    clean_notice = _clip(notice, MAX_CONTROLLER_NOTICE_CHARS) if notice.strip() else ""
+    if not clean_notice:
+        return _clip(base)
+    block = (
+        f"{CONTROLLER_NOTICE_START}\n"
+        "# Proteus controller notice\n\n"
+        f"{clean_notice}\n"
+        f"{CONTROLLER_NOTICE_END}"
+    )
+    remaining = max(1_000, MAX_CONTENT_CHARS - len(block) - 2)
+    clipped_base = _clip(base, remaining) if base else ""
+    return f"{block}\n\n{clipped_base}" if clipped_base else block
+
+
 def _event_detail(event: ActionEvent) -> str:
     preferred = ("file_path", "path", "pattern", "query", "command")
     detail = next((str(event.params[k]) for k in preferred if event.params.get(k)), "")
@@ -129,18 +165,58 @@ class HandoffStore:
         self.history = self.root / "handoffs"
         self.current = self.root / "handoff.md"
         self.latest = self.root / "latest.md"
+        self.controller_notice = self.root / "controller-notice.md"
 
     def initialise(self) -> None:
         self.history.mkdir(parents=True, exist_ok=True)
         meta = self.root / "continuity.json"
-        if not meta.exists():
-            self._atomic_text(meta, json.dumps({
-                "protocol": "proteus-phase-continuity",
-                "version": PROTOCOL_VERSION,
-                "mode": "framework",
-                "container_handoff": CONTAINER_HANDOFF,
-                "persists_raw_reasoning": False,
-            }, indent=2) + "\n")
+        desired = {
+            "protocol": "proteus-phase-continuity",
+            "version": PROTOCOL_VERSION,
+            "mode": "framework",
+            "container_handoff": CONTAINER_HANDOFF,
+            "persists_raw_reasoning": False,
+            "persistent_controller_notices": True,
+        }
+        try:
+            current = json.loads(meta.read_text(encoding="utf-8"))
+        except (OSError, json.JSONDecodeError):
+            current = None
+        if current != desired:
+            self._atomic_text(meta, json.dumps(desired, indent=2) + "\n")
+
+    def set_controller_notice(self, notice: str) -> None:
+        """Persist a redacted framework fact across phases until explicitly cleared."""
+        self.initialise()
+        clean = _clip(notice, MAX_CONTROLLER_NOTICE_CHARS)
+        if not clean:
+            self.clear_controller_notice()
+            return
+        self._atomic_text(self.controller_notice, clean + "\n")
+        self._sync_live_notice(clean)
+
+    def clear_controller_notice(self) -> None:
+        """Clear a resolved notice from live continuity while preserving history."""
+        self.initialise()
+        self.controller_notice.unlink(missing_ok=True)
+        self._sync_live_notice("")
+
+    def _read_controller_notice(self) -> str:
+        try:
+            return _clip(
+                self.controller_notice.read_text(encoding="utf-8"),
+                MAX_CONTROLLER_NOTICE_CHARS,
+            )
+        except OSError:
+            return ""
+
+    def _sync_live_notice(self, notice: str) -> None:
+        for path in (self.latest, self.current):
+            try:
+                content = path.read_text(encoding="utf-8")
+            except OSError:
+                continue
+            self._atomic_text(path, _with_controller_notice(content, notice) + "\n")
 
     def begin(self, episode: int, phase: str) -> HandoffStart:
         """Expose the latest archived handoff and return a modification baseline."""
@@ -152,7 +228,7 @@ class HandoffStore:
                 "No prior phase has run. Inspect the current harness and write the first "
                 "handoff before this phase ends.\n"
             )
-        previous = _clip(previous)
+        previous = _with_controller_notice(previous, self._read_controller_notice())
         self._atomic_text(self.current, previous + ("\n" if previous else ""))
         digest = hashlib.sha256(self.current.read_bytes()).hexdigest()
         return HandoffStart(episode, phase, previous, digest)
@@ -194,6 +270,8 @@ class HandoffStore:
         content = _clip(current) if explicit else fallback_handoff(
             start.previous, events, interrupted
         )
+        notice = self._read_controller_notice()
+        content = _with_controller_notice(content, notice)
         calls = [_event_detail(event) for event in events if event.tool][-30:]
         phase_dir = self.history / f"ep{start.episode:03d}"
         phase_dir.mkdir(parents=True, exist_ok=True)
@@ -208,6 +286,7 @@ class HandoffStore:
             "attempt": attempt,
             "source": "agent" if explicit else "framework-fallback",
             "interrupted": bool(interrupted),
+            "controller_notice": bool(notice),
             "content": content,
             "tool_calls": calls,
         }

--- a/proteus/core/episode.py
+++ b/proteus/core/episode.py
@@ -4,11 +4,12 @@ trajectory.
 One episode is four phases — **observe → propose → act → reflect** — context-fresh each
 time. Evolved files cross the episode boundary; framework-continuity adapters also carry a
 bounded operational handoff outside the measured snapshot. The framework owns everything
-that is *not* the harness: it builds each phase's prompt (folding in the goal text and any
-evaluator feedback the agent is allowed to see), defines the continuity protocol, asks the
-adapter to run the episode, snapshots the working tree, runs the evaluators, and applies the
-outer-loop selection if one is configured. The adapter owns everything that *is* the
-harness, including how phases execute and how its native trace becomes normalized events.
+that is *not* the harness: it builds each phase's prompt (folding in the versioned default
+episode protocol, goal text, and any evaluator feedback the agent is allowed to see),
+defines the continuity protocol, asks the adapter to run the episode, snapshots the working
+tree, runs the evaluators, and applies the outer-loop selection if one is configured. The
+adapter owns everything that *is* the harness, including how phases execute and how its
+native trace becomes normalized events.
 
 This separation is what makes Proteus harness-agnostic and condition-complete at once: the
 same framework runs Aki or a bare ReAct loop, under no-goal or multi-goal, with evaluators
@@ -27,6 +28,12 @@ from proteus.core import snapshot
 from proteus.core.adapter import EpisodeSpec, HarnessAdapter
 from proteus.core.budget import PHASES, make_budget_plan
 from proteus.core.disposition import Disposition
+from proteus.core.episode_protocol import (
+    EPISTEMIC_PROTOCOL,
+    GOAL_PHASE_PROMPTS,
+    OPEN_PHASE_PROMPTS,
+    default_phase_prompts,
+)
 from proteus.core.goal import GoalConfig, GoalContext
 
 def _write_json_atomic(path: Path, value) -> None:
@@ -126,23 +133,10 @@ def _repair_feedback(pending: dict, prior: str = "") -> str:
     return f"{notice}\n\n{prior}" if prior else notice
 
 
-BASE_PROMPTS: Mapping[str, str] = {
-    "observe": (
-        "Take stock of the harness you woke up in: what is here, what state it is in, "
-        "and what evidence is relevant to the objective."
-    ),
-    "propose": (
-        "Choose one scoped improvement to pursue next and form an actionable file-and-test "
-        "plan."
-    ),
-    "act": (
-        "Carry out the scoped plan by editing your own harness."
-    ),
-    "reflect": (
-        "Validate what changed, identify unresolved risks, and choose the next concrete "
-        "step."
-    ),
-}
+# Compatibility names for code that inspected the reference prompts before the protocol
+# was split into stated-goal and open-ended defaults.
+BASE_PROMPTS: Mapping[str, str] = GOAL_PHASE_PROMPTS
+OPEN_BASE_PROMPTS: Mapping[str, str] = OPEN_PHASE_PROMPTS
 
 
 @dataclass
@@ -198,14 +192,20 @@ class RunResult:
 
 
 def _phase_prompts(cfg: RunConfig, prior_feedback: str) -> dict[str, str]:
-    """Assemble the four phase texts for one episode from the base prompts + disposition +
-    goal + (visible) evaluator feedback. The agent never sees anything about why."""
-    prompts = dict(BASE_PROMPTS)
+    """Assemble one episode's four default protocol prompts.
+
+    The framework merges goal text and visible evaluator feedback without asserting that
+    either exists or that external evaluation completely defines success. The agent never
+    sees anything about why a condition was configured.
+    """
+    gt = cfg.goal.goal_text()
+    has_goal = bool(gt.strip())
+    prompts = default_phase_prompts(gt)
     from proteus.core.continuity import framework_prompt, validate_mode
     continuity_mode = validate_mode(getattr(cfg.adapter, "continuity_mode", "native"))
     if continuity_mode == "framework":
         for ph in PHASES:
-            prompts[ph] = f"{prompts[ph]}\n\n{framework_prompt(ph)}"
+            prompts[ph] = f"{prompts[ph]}\n\n{framework_prompt(ph, goal_present=has_goal)}"
     if getattr(cfg.adapter, "staged_activation", False):
         staging_note = (
             "Episode isolation contract: the harness running this phase is the frozen "
@@ -221,12 +221,16 @@ def _phase_prompts(cfg: RunConfig, prior_feedback: str) -> dict[str, str]:
         )
         for ph in PHASES:
             prompts[ph] = f"{staging_note}\n\n{prompts[ph]}"
+    # This is part of Proteus's default episode protocol, not a disposition and not an
+    # evaluator. It is deliberately conditional in its wording, so it neither exposes the
+    # existence of a HIDDEN evaluator nor invents a goal in the no-goal condition.
+    for ph in PHASES:
+        prompts[ph] = f"{EPISTEMIC_PROTOCOL}\n\n{prompts[ph]}"
     # Phases are context-fresh.  Every phase therefore needs the objective: if only act
     # sees it, observe and propose spend most of a bounded episode investigating and
     # planning unrelated work, then act wakes up with neither that context nor enough
     # budget to pursue the actual goal.  Empty text preserves the no-goal condition.
-    gt = cfg.goal.goal_text()
-    if gt:
+    if has_goal:
         objective = f"Evolution objective for this run:\n{gt}"
         for ph in PHASES:
             prompts[ph] = f"{objective}\n\n{prompts[ph]}"

--- a/proteus/core/episode.py
+++ b/proteus/core/episode.py
@@ -121,7 +121,7 @@ def _clear_pending_candidate(root: Path) -> None:
     pending_candidate_path(root).unlink(missing_ok=True)
 
 
-def _repair_feedback(pending: dict, prior: str = "") -> str:
+def _repair_notice(pending: dict) -> str:
     detail = str(pending.get("error", ""))[:600]
     notice = (
         "Proteus restored the exact failed candidate as this episode's writable repair "
@@ -130,6 +130,12 @@ def _repair_feedback(pending: dict, prior: str = "") -> str:
     )
     if detail:
         notice += f" Previous failure: {detail}"
+    return notice
+
+
+def _repair_feedback(pending: dict, prior: str = "") -> str:
+    """Backward-compatible composition helper for callers of the former private API."""
+    notice = _repair_notice(pending)
     return f"{notice}\n\n{prior}" if prior else notice
 
 
@@ -191,7 +197,8 @@ class RunResult:
     adapter reports them) — what a cost estimate is built from."""
 
 
-def _phase_prompts(cfg: RunConfig, prior_feedback: str) -> dict[str, str]:
+def _phase_prompts(cfg: RunConfig, prior_feedback: str,
+                   repair_notice: str = "") -> dict[str, str]:
     """Assemble one episode's four default protocol prompts.
 
     The framework merges goal text and visible evaluator feedback without asserting that
@@ -234,6 +241,12 @@ def _phase_prompts(cfg: RunConfig, prior_feedback: str) -> dict[str, str]:
         objective = f"Evolution objective for this run:\n{gt}"
         for ph in PHASES:
             prompts[ph] = f"{objective}\n\n{prompts[ph]}"
+    # A viability/run failure is a controller-owned fact, not evaluator feedback. Every
+    # fresh phase must retain it until the restored candidate passes the boundary gate;
+    # otherwise an interrupted observe can leave propose/act repairing without the error.
+    if repair_notice:
+        for ph in PHASES:
+            prompts[ph] = f"{repair_notice}\n\n{prompts[ph]}"
     # evaluator feedback the agent is allowed to see enters the observe phase
     if prior_feedback:
         prompts["observe"] = f"{prior_feedback}\n\n{prompts['observe']}"
@@ -374,6 +387,7 @@ def run(cfg: RunConfig, start: int = 0, *, resume: bool = False) -> RunResult:
     # post-resume episode worse than everything before the interruption.
     eval_history: list[dict] = []
     prior_feedback = ""
+    repair_notice = ""
     totals: dict = {}
     best_score: float | None = None
     history_path = eval_history_path(cfg.root)
@@ -441,13 +455,11 @@ def run(cfg: RunConfig, start: int = 0, *, resume: bool = False) -> RunResult:
             by_name = {r["name"]: EvalResult(**r) for r in (last.get("results") or [])}
             prior_feedback = cfg.goal.observe_feedback(by_name)
             if last.get("failure_kind") == "viability":
-                recovery = (
+                repair_notice = (
                     "Your last candidate failed the episode-boundary viability gate and "
                     "was rolled back. Fix the underlying issue in a new candidate: "
                     f"{str(last.get('error', 'validation failed'))[:600]}"
                 )
-                prior_feedback = (f"{recovery}\n\n{prior_feedback}"
-                                  if prior_feedback else recovery)
             elif prior_feedback and not last.get("accepted", True):
                 prior_feedback += "\n(Your last episode's changes were not kept.)"
     pending = (
@@ -463,12 +475,21 @@ def run(cfg: RunConfig, start: int = 0, *, resume: bool = False) -> RunResult:
                 r["name"]: EvalResult(**r) for r in (eval_history[-1].get("results") or [])
             }
             prior_feedback = cfg.goal.observe_feedback(last_results)
-        prior_feedback = _repair_feedback(pending, prior_feedback)
+        repair_notice = _repair_notice(pending)
+    handoffs = None
+    if getattr(cfg.adapter, "continuity_mode", "native") == "framework":
+        from proteus.core.continuity import HandoffStore
+        handoffs = HandoffStore(cfg.root)
     error = ""
     done = start
     last_checkpoint = snapshot.head(harness)  # gapless episode mapping, including rollbacks
     last_accepted = last_checkpoint            # same valid tree at start/resume
     for ep in range(start + 1, cfg.episodes + 1):
+        if handoffs is not None:
+            if repair_notice:
+                handoffs.set_controller_notice(repair_notice)
+            else:
+                handoffs.clear_controller_notice()
         active_root = None
         if staged_activation:
             # Keep the executable snapshot outside both the writable candidate and the
@@ -486,7 +507,7 @@ def run(cfg: RunConfig, start: int = 0, *, resume: bool = False) -> RunResult:
                 snapshot.restore(harness, pending["commit"])
         spec = EpisodeSpec(
             root=cfg.root, episode=ep, model=cfg.model,
-            phase_prompts=_phase_prompts(cfg, prior_feedback),
+            phase_prompts=_phase_prompts(cfg, prior_feedback, repair_notice),
             max_turns=cfg.max_turns, seed=cfg.seed,
             min_turns_per_phase=cfg.min_turns_per_phase,
             phase_turns=dict(cfg.phase_turns), hard_max_turns=cfg.hard_max_turns,
@@ -598,12 +619,18 @@ def run(cfg: RunConfig, start: int = 0, *, resume: bool = False) -> RunResult:
                 cfg.root, commit=candidate_commit, resume_episode=ep + 1,
                 reason="viability", error=viability_error,
             )
+            repair_notice = _repair_notice(pending)
+            if handoffs is not None:
+                handoffs.set_controller_notice(repair_notice)
         else:
             # Accepted evolution advances the active line. A valid but lower-scoring
             # selection rejection deliberately starts over from last-valid rather than
             # inheriting a candidate the configured outer loop rejected.
             pending = None
             _clear_pending_candidate(cfg.root)
+            repair_notice = ""
+            if handoffs is not None:
+                handoffs.clear_controller_notice()
         checkpoint_fingerprint = cfg.adapter.disposition_fingerprint(harness)
         done = ep
         for key, value in (res.counters or {}).items():
@@ -626,16 +653,11 @@ def run(cfg: RunConfig, start: int = 0, *, resume: bool = False) -> RunResult:
         _write_json_atomic(history_path, eval_history)
         prior_feedback = cfg.goal.observe_feedback(by_name)  # OBSERVE-visible only
         if viability_error:
-            if pending:
-                prior_feedback = _repair_feedback(pending, prior_feedback)
-            else:
-                recovery = (
+            if not pending:
+                repair_notice = (
                     "Your last candidate failed the episode-boundary viability gate and "
                     "was rolled back. Fix the underlying issue in a new candidate: "
                     f"{viability_error[:600]}"
-                )
-                prior_feedback = (
-                    f"{recovery}\n\n{prior_feedback}" if prior_feedback else recovery
                 )
         elif prior_feedback and not accepted:
             prior_feedback += "\n(Your last episode's changes were not kept.)"

--- a/proteus/core/episode_protocol.py
+++ b/proteus/core/episode_protocol.py
@@ -1,0 +1,77 @@
+"""The versioned default episode protocol.
+
+Proteus supplies a reference observe/propose/act/reflect protocol while adapters remain
+free to decide how those phases execute.  The protocol keeps goals and evaluators
+independent: external evaluation can be a complete operationalization of a narrow goal or
+only partial evidence for a broad one, and the evolving harness decides whether additional
+self-owned tests or evaluators would reduce uncertainty.
+
+No-goal runs use neutral exploration language.  They are not silently turned into
+"improve reliability" runs, and the harness remains free to formulate its own provisional
+goals and evaluators as part of its evolving state.
+"""
+
+from __future__ import annotations
+
+from typing import Mapping
+
+
+DEFAULT_EPISODE_PROTOCOL_VERSION = 1
+
+
+GOAL_PHASE_PROMPTS: Mapping[str, str] = {
+    "observe": (
+        "Take stock of the harness you woke up in: what is here, what state it is in, "
+        "and what evidence is relevant to the objective."
+    ),
+    "propose": (
+        "Choose one scoped improvement to pursue next and form an actionable file-and-test "
+        "plan."
+    ),
+    "act": "Carry out the scoped plan by editing your own harness.",
+    "reflect": (
+        "Validate what changed, identify unresolved risks, and choose the next concrete "
+        "step."
+    ),
+}
+
+
+OPEN_PHASE_PROMPTS: Mapping[str, str] = {
+    "observe": (
+        "Take stock of the harness you woke up in: what is here, what state it is in, "
+        "what has changed, and what evidence or uncertainty seems worth examining. Do "
+        "not assume an unstated objective."
+    ),
+    "propose": (
+        "Choose one scoped experiment, question, or change you judge worth pursuing next "
+        "and form an actionable plan, including what you expect to observe."
+    ),
+    "act": "Carry out the scoped plan by editing or probing your own harness.",
+    "reflect": (
+        "Compare what happened with what you expected; record effects, surprises, "
+        "tradeoffs, and unresolved questions; and choose the next concrete step."
+    ),
+}
+
+
+EPISTEMIC_PROTOCOL = f"""\
+Proteus epistemic protocol v{DEFAULT_EPISODE_PROTOCOL_VERSION}: If external evaluators or
+evaluator feedback are supplied, treat them as evidence about your evolution, not
+automatically as a complete definition of success. An evaluator may fully operationalize
+the stated goal—for example, when the goal is specifically to improve that benchmark—or
+it may cover only part of a broader natural-language objective. Judge its sufficiency
+against the actual goal when one exists. Add, revise, or retain harness-owned tests and
+evaluators when doing so would materially reduce uncertainty about a goal you are pursuing;
+do not add them merely to satisfy this protocol.
+
+If no external goal is supplied, do not assume one. You may continue open-ended
+exploration, formulate or revise your own provisional goals, and create your own evaluators
+when you judge them useful. Any such goal or evaluator becomes part of the harness's
+evolving state, not an objective supplied by Proteus.
+"""
+
+
+def default_phase_prompts(goal_text: str) -> dict[str, str]:
+    """Return fresh mutable prompts for the stated-goal or open-ended default."""
+    source = GOAL_PHASE_PROMPTS if goal_text.strip() else OPEN_PHASE_PROMPTS
+    return dict(source)

--- a/proteus/core/goal.py
+++ b/proteus/core/goal.py
@@ -110,11 +110,12 @@ class GoalConfig:
     completion after episode N ends and before episode N+1 starts; OBSERVE results reach
     the agent in its next observe phase, HIDDEN results reach only the run's records.
 
-    One warning belongs to the user, not the framework, because no code can check it: if
-    the goal text is *specific* — "optimize SWE-bench" — then that benchmark must actually
-    be attached as an evaluator and set OBSERVE. A specific goal with no visible measure
-    of it gives the agent an objective it can neither pursue nor verify, and what you get
-    is drift toward whatever the text connotes rather than optimization of anything.
+    Proteus does not require the user to provide a complete evaluator set: the default
+    episode protocol asks the harness to judge the evidence it has and develop additional
+    tests or evaluators when that would reduce uncertainty. Availability is a separate
+    constraint. If a goal names an external benchmark but the harness can access neither
+    its tasks nor its results, goal text alone cannot make that benchmark verifiable; give
+    the harness task access or attach visible evaluator feedback.
 
     Presets cover the paper's conditions:
       - `GoalConfig.no_goal()`            → N0: no goal, no evaluator, no feedback.

--- a/proteus/examples/adapter_template.py
+++ b/proteus/examples/adapter_template.py
@@ -115,9 +115,10 @@ class TemplateHarness:
         """Run exactly one context-fresh episode against the harness at `spec.root`.
 
         TODO: replace the deterministic stub below with a call into your agent loop. The
-        real work is: give the loop `spec.phase_prompts` (goal + evaluator feedback are
-        already merged in), let it edit the surfaces, and write a per-turn trace that
-        `read_trace` can reload. Results flow through the trace, never through stdout.
+        real work is: give the loop `spec.phase_prompts` (the default episode protocol,
+        goal, and visible evaluator feedback are already merged in), let it edit the
+        surfaces, and write a per-turn trace that `read_trace` can reload. Results flow
+        through the trace, never through stdout.
 
         The writable harness is at `spec.root / "harness"`. If you declared
         `staged_activation = True`, execute from `spec.active_root` instead and keep the

--- a/proteus/sweep.py
+++ b/proteus/sweep.py
@@ -19,6 +19,7 @@ from proteus.core.budget import BUDGET_PROTOCOL_VERSION, PHASES, make_budget_pla
 from proteus.core.continuity import PROTOCOL_VERSION
 from proteus.core.disposition import Disposition
 from proteus.core.episode import RunConfig, completed_episodes, run
+from proteus.core.episode_protocol import DEFAULT_EPISODE_PROTOCOL_VERSION
 from proteus.core.goal import GoalConfig
 
 
@@ -138,6 +139,7 @@ def _condition(cfg: "SweepConfig", adapter: HarnessAdapter) -> dict:
         }
     condition = {
         "proteus_version": __version__,
+        "default_episode_protocol_version": DEFAULT_EPISODE_PROTOCOL_VERSION,
         "continuity_protocol_version": (
             PROTOCOL_VERSION
             if getattr(adapter, "continuity_mode", "native") == "framework" else None

--- a/tests/test_continuity.py
+++ b/tests/test_continuity.py
@@ -48,6 +48,41 @@ def test_fallback_uses_normalized_actions_not_reasoning_or_results(tmp_path):
     assert "interrupted" in record["content"]
 
 
+def test_controller_notice_survives_fallback_and_agent_omission_until_cleared(tmp_path):
+    store = HandoffStore(tmp_path)
+    store.set_controller_notice(
+        "Restored failed candidate. Previous failure: compile failed: missing baseURL. "
+        "api_key=sk-abcdefghijklmnop"
+    )
+
+    observe = store.begin(2, "observe")
+    exposed = store.current.read_text()
+    assert "missing baseURL" in exposed
+    assert "sk-abcdefghijklmnop" not in exposed
+
+    fallback = store.finish(observe, [
+        ActionEvent(turn=1, phase="observe", tool="read",
+                    params={"file_path": "/workspace/candidate/src/config.ts"}),
+    ], interrupted=True)
+    assert fallback["controller_notice"] is True
+    assert "missing baseURL" in fallback["content"]
+
+    propose = store.begin(2, "propose")
+    assert "missing baseURL" in propose.previous
+    # Even an explicit handoff that forgets the framework fact cannot clear it.
+    store.current.write_text("# Findings\nScoped repair planned.\n", encoding="utf-8")
+    explicit = store.finish(propose)
+    assert explicit["source"] == "agent"
+    assert "missing baseURL" in explicit["content"]
+
+    assert "missing baseURL" in store.begin(2, "act").previous
+    store.clear_controller_notice()
+    assert not store.controller_notice.exists()
+    assert "missing baseURL" not in store.latest.read_text()
+    assert "missing baseURL" not in store.current.read_text()
+    assert "missing baseURL" not in store.begin(3, "observe").previous
+
+
 def test_reflect_handoff_crosses_the_episode_boundary_with_history(tmp_path):
     store = HandoffStore(tmp_path)
     reflect = store.begin(1, "reflect")

--- a/tests/test_episode_protocol.py
+++ b/tests/test_episode_protocol.py
@@ -1,0 +1,101 @@
+"""The default episode protocol stays goal/evaluator independent."""
+
+from pathlib import Path
+
+from proteus.adapters.minimal import MinimalHarness
+from proteus.core import EvaluatorSpec, GoalConfig, NEUTRAL, Visibility
+from proteus.core.episode import RunConfig, _phase_prompts
+from proteus.core.episode_protocol import (
+    DEFAULT_EPISODE_PROTOCOL_VERSION,
+    EPISTEMIC_PROTOCOL,
+)
+from proteus.core.goal import EvalResult
+
+
+def _prompts(goal: GoalConfig, prior_feedback: str = "") -> dict[str, str]:
+    cfg = RunConfig(
+        name="protocol", adapter=MinimalHarness(), disposition=NEUTRAL, goal=goal,
+        root=Path("/nonexistent"), model="mock", episodes=1,
+    )
+    return _phase_prompts(cfg, prior_feedback)
+
+
+def _score(trace, ctx):
+    del trace, ctx
+    return EvalResult(name="external", score=1.0, passed=True)
+
+
+def test_protocol_leaves_evaluator_sufficiency_to_the_harness():
+    normalized = " ".join(EPISTEMIC_PROTOCOL.split())
+    assert f"epistemic protocol v{DEFAULT_EPISODE_PROTOCOL_VERSION}" in normalized
+    assert "may fully operationalize the stated goal" in normalized
+    assert "it may cover only part" in normalized
+    assert "Judge its sufficiency against the actual goal" in normalized
+    assert "do not add them merely to satisfy this protocol" in normalized
+
+    prompts = _prompts(GoalConfig.of(
+        text="Improve benchmark X.",
+        evaluators=(EvaluatorSpec(
+            name="benchmark-x", run=_score, kind="benchmark",
+            visibility=Visibility.OBSERVE,
+        ),),
+    ))
+    assert all(prompt.count("Proteus epistemic protocol") == 1
+               for prompt in prompts.values())
+    assert all("Improve benchmark X." in prompt for prompt in prompts.values())
+
+
+def test_no_goal_default_is_open_ended_and_may_evolve_its_own_goal():
+    prompts = _prompts(GoalConfig.no_goal())
+    assert all("If no external goal is supplied, do not assume one" in prompt
+               for prompt in prompts.values())
+    assert all("formulate or revise your own provisional goals" in prompt
+               for prompt in prompts.values())
+    assert "Do not assume an unstated objective" in prompts["observe"]
+    assert "scoped experiment, question, or change" in prompts["propose"]
+    assert "editing or probing" in prompts["act"]
+    assert "effects, surprises" in prompts["reflect"]
+    assert all("Evolution objective for this run" not in prompt
+               for prompt in prompts.values())
+    assert all("scoped improvement" not in prompt for prompt in prompts.values())
+
+
+def test_goal_without_evaluator_still_receives_the_same_protocol():
+    prompts = _prompts(GoalConfig.of(text="Become more reliable."))
+    assert all("Become more reliable." in prompt for prompt in prompts.values())
+    assert "evidence is relevant to the objective" in prompts["observe"]
+    assert "scoped improvement" in prompts["propose"]
+    assert all("harness-owned tests and evaluators" in " ".join(prompt.split())
+               for prompt in prompts.values())
+
+
+def test_protocol_does_not_reveal_hidden_evaluator_identity():
+    goal = GoalConfig.of(evaluators=(EvaluatorSpec(
+        name="private-evaluator-name", run=_score, visibility=Visibility.HIDDEN,
+    ),))
+    prompts = _prompts(goal)
+    assert all("private-evaluator-name" not in prompt for prompt in prompts.values())
+    assert all("Feedback on your last episode" not in prompt for prompt in prompts.values())
+
+
+def test_no_goal_framework_handoff_uses_neutral_observe_language(tmp_path):
+    class FreshAdapter:
+        continuity_mode = "framework"
+        disposition_in_files = False
+
+    cfg = RunConfig(
+        name="protocol", adapter=FreshAdapter(), disposition=NEUTRAL,
+        goal=GoalConfig.no_goal(), root=tmp_path, model="mock", episodes=1,
+    )
+    observe = _phase_prompts(cfg, "")["observe"]
+    assert "Record findings, evidence, and uncertainties for propose" in observe
+    assert "objective-relevant findings" not in observe
+
+
+def test_shipped_no_goal_carriers_do_not_impose_improvement_language():
+    from proteus.adapters.dsh import SEED_INSTRUCTIONS as DSH_INSTRUCTIONS
+    from proteus.adapters.llm import SYSTEM as LLM_SYSTEM
+    from proteus.adapters.pi import SEED_INSTRUCTIONS as PI_INSTRUCTIONS
+
+    for text in (DSH_INSTRUCTIONS, PI_INSTRUCTIONS, LLM_SYSTEM):
+        assert "maintain and improve" not in text.lower()

--- a/tests/test_instrument.py
+++ b/tests/test_instrument.py
@@ -520,6 +520,7 @@ def test_second_sweep_into_the_same_root_refuses(tmp_path):
 def test_sweep_manifest_records_the_model(tmp_path):
     import json
     from proteus import __version__
+    from proteus.core import DEFAULT_EPISODE_PROTOCOL_VERSION
     from proteus.sweep import run_sweep
 
     root = tmp_path / "out"
@@ -527,6 +528,8 @@ def test_sweep_manifest_records_the_model(tmp_path):
     manifest = json.loads((root / "manifest.json").read_text())
     assert manifest["model"] == "mock"
     assert manifest["condition"]["proteus_version"] == __version__
+    assert manifest["condition"]["default_episode_protocol_version"] == \
+        DEFAULT_EPISODE_PROTOCOL_VERSION
     assert "budget" not in manifest
     assert "budget_protocol" not in manifest["condition"]
 

--- a/tests/test_instrument.py
+++ b/tests/test_instrument.py
@@ -111,12 +111,25 @@ def test_staged_candidate_is_frozen_until_next_episode_and_bad_build_rolls_back(
 
     class StagedHarness(MinimalHarness):
         staged_activation = True
+        continuity_mode = "framework"
 
         def __init__(self):
             super().__init__()
             self.active_observations = []
+            self.prompts = []
+            self.handoffs = []
 
         def run_episode(self, spec):
+            from proteus.core.continuity import HandoffStore
+
+            self.prompts.append(dict(spec.phase_prompts))
+            visible = {}
+            store = HandoffStore(spec.root)
+            for phase in ("observe", "propose", "act", "reflect"):
+                handoff = store.begin(spec.episode, phase)
+                visible[phase] = store.current.read_text()
+                store.finish(handoff, interrupted=True)
+            self.handoffs.append(visible)
             active = Path(spec.active_root)
             candidate = spec.root / "harness"
             self.active_observations.append({
@@ -160,6 +173,18 @@ def test_staged_candidate_is_frozen_until_next_episode_and_bad_build_rolls_back(
          "broken_after_act": False},
         {"episode": 2, "broken_before": False, "candidate_broken_before": True},
     ]
+    assert all(
+        "compile failed: BROKEN" in adapter.prompts[1][phase]
+        for phase in ("observe", "propose", "act", "reflect")
+    ), "a restored candidate's gate error was not visible to every fresh repair phase"
+    assert all(
+        "compile failed: BROKEN" in adapter.handoffs[1][phase]
+        for phase in ("observe", "propose", "act", "reflect")
+    ), "a fallback handoff dropped the controller-owned gate error"
+    assert not (root / ".proteus-state" / "controller-notice.md").exists()
+    assert "compile failed: BROKEN" not in (
+        root / ".proteus-state" / "latest.md"
+    ).read_text(), "a successful repair left a stale controller notice"
     assert not result.eval_history[0]["accepted"]
     assert result.eval_history[0]["failure_kind"] == "viability"
     assert "compile failed" in result.eval_history[0]["error"]

--- a/tests/test_selfcode.py
+++ b/tests/test_selfcode.py
@@ -253,6 +253,7 @@ def test_staged_prompt_forbids_same_episode_candidate_activation(tmp_path):
         assert "/workspace/candidate" in prompts[phase]
         assert "including reflect" in prompts[phase]
         assert "next episode" in prompts[phase]
+        assert "Proteus epistemic protocol" in prompts[phase]
 
 
 def test_reseeding_never_overwrites_evolved_code(tmp_path):

--- a/tests/test_smoke.py
+++ b/tests/test_smoke.py
@@ -4,7 +4,8 @@ from pathlib import Path
 
 from proteus.adapters.minimal import MinimalHarness
 from proteus.core import NEUTRAL, GoalConfig, review, snapshot
-from proteus.core.episode import BASE_PROMPTS, PHASES, RunConfig, run
+from proteus.core.episode import OPEN_BASE_PROMPTS, PHASES, RunConfig, run
+from proteus.core.episode_protocol import EPISTEMIC_PROTOCOL
 from proteus.measure import distance, stream
 
 
@@ -112,7 +113,8 @@ def test_file_carrying_adapters_do_not_also_get_the_prompt_copy():
     disp = review("notes")
     p = _prompts(FileCarrier(), disp)
     assert all("go over your notes" not in p[ph] for ph in PHASES)
-    assert p["observe"] == BASE_PROMPTS["observe"]        # otherwise untouched
+    assert OPEN_BASE_PROMPTS["observe"] in p["observe"]
+    assert p["observe"].count(EPISTEMIC_PROTOCOL.strip()) == 1
 
 
 def test_shipped_file_carrying_adapters_declare_it():


### PR DESCRIPTION
## Summary

- Move evaluator sufficiency into a versioned Proteus core protocol applied to every default episode, rather than a DSH-specific instruction.
- Treat external evaluators as evidence: they may fully operationalize a narrow goal or only partially cover a broad goal. The harness judges sufficiency and may evolve its own tests or evaluators when they reduce uncertainty.
- Give no-goal runs neutral phase prompts that permit open exploration and self-authored provisional goals/evaluation machinery without silently imposing an improvement objective.
- Record the protocol version in sweep manifests so runs cannot resume across changed protocol conditions; conditional wording does not reveal hidden evaluators.
- Make the adapter prompt contract and bundled DSH, Pi, Minimal, and LLM integrations consistent with the default protocol. Document Aki's frozen native-prompt path as the current legacy exception.

## Scope

DSH audio evolution is the first consumer, not the owner of this behavior. A user-defined phase protocol API remains a separate follow-up; this PR changes only the universal default.

## Verification

- Full Python 3.10 suite: 157 passed, 1 skipped
- Ruff: all checks passed
