### PR TITLE
feat: add codex as a new adapter

### DIFF
--- a/README.md
+++ b/README.md
@@ -100,11 +100,12 @@ An installed action preference measurably shifts what the harness grows — and 
 | `llm` | the same harness driven by a live model — any OpenAI-compatible endpoint, DeepSeek by default | an API key |
 | `dsh` | [DeepSeek Harness](https://github.com/deepseek-ai/deepseek-harness), headless profile, in a prepared container | Docker + a DeepSeek key |
 | `pi` | [Pi](https://github.com/badlogic/pi-mono) — Mario Zechner's minimal coding harness (4 tools, native AGENTS.md + skills) | Docker + a DeepSeek key |
+| `codex` | [OpenAI Codex CLI](https://github.com/openai/codex) — pinned, source-evolving Rust harness using native `codex exec --json` traces | Docker + Codex auth/API key |
 | `aki` | the Aki research harness (the paper's apparatus) | the research checkout |
 | yours | `--harness <module>:<Class>` — no registration | your adapter |
 
-`dsh` and `pi` are the source-evolving third-party integrations. At seed time each adapter
-extracts the pinned harness's real TypeScript source into `harness/src/`. During episode N,
+`dsh`, `pi`, and `codex` are the source-evolving third-party integrations. At seed time each
+adapter extracts the pinned harness's real source into `harness/src/`. During episode N,
 all four phases boot the same read-only last-valid snapshot while writing a separate
 candidate. After reflect, Proteus rebuilds and validates the candidate; only a passing
 candidate activates in episode N+1. A failed build is prevented from activating, while

--- a/environments/codex-src/Dockerfile
+++ b/environments/codex-src/Dockerfile
@@ -18,9 +18,13 @@ RUN for i in 1 2 3 4 5; do \
     && git checkout --detach "$CODEX_REF" \
     && git submodule update --init --recursive
 
-# Warm the exact Cargo dependency/build cache once in the image.
+# Warm the exact Cargo dependency/build cache once in the image. Override
+# CARGO_BUILD_JOBS on memory-constrained build hosts (rustc's LTO codegen for the
+# largest crates can OOM at full `-j nproc` parallelism on small boxes).
+ARG CARGO_BUILD_JOBS=
 RUN cd /opt/src/codex-rs \
     && cargo fetch --locked \
+    && if [ -n "$CARGO_BUILD_JOBS" ]; then export CARGO_BUILD_JOBS; fi \
     && CARGO_TARGET_DIR=/opt/codex-target cargo build --locked -p codex-cli --release
 
 # Seed tar is exactly the source used above; generated build state and .git are excluded.

--- a/environments/codex-src/Dockerfile
+++ b/environments/codex-src/Dockerfile
@@ -1,0 +1,28 @@
+# Source-evolving OpenAI Codex environment for Proteus.
+# Pin by immutable SHA for reproducible experiments.
+FROM rust:1.95-bookworm
+
+ARG CODEX_REF=eb15245d820d094cc0e5a950bc052bd7c2c5f925
+ENV DEBIAN_FRONTEND=noninteractive
+RUN apt-get update && apt-get install -y --no-install-recommends \
+      git ca-certificates pkg-config libssl-dev libcap-dev clang cmake python3 jq rsync zstd \
+    && rm -rf /var/lib/apt/lists/*
+
+RUN git clone https://github.com/openai/codex.git /opt/src \
+    && cd /opt/src \
+    && git checkout --detach "$CODEX_REF" \
+    && git submodule update --init --recursive
+
+# Warm the exact Cargo dependency/build cache once in the image.
+RUN cd /opt/src/codex-rs \
+    && cargo fetch --locked \
+    && CARGO_TARGET_DIR=/opt/codex-target cargo build --locked -p codex-cli --release
+
+# Seed tar is exactly the source used above; generated build state and .git are excluded.
+RUN tar --exclude=.git --exclude=target -cf /opt/codex-source.tar -C /opt/src . \
+    && cp -a /usr/local/cargo /opt/cargo-home-seed \
+    && chmod -R a+rX /opt/cargo-home-seed /opt/codex-target /opt/src /opt/codex-source.tar
+
+COPY boot.sh /usr/local/bin/proteus-codex
+RUN chmod +x /usr/local/bin/proteus-codex
+ENTRYPOINT ["/usr/local/bin/proteus-codex"]

--- a/environments/codex-src/Dockerfile
+++ b/environments/codex-src/Dockerfile
@@ -47,7 +47,7 @@ RUN cd /opt/src/codex-rs \
     && cp "$V8_DIR/$ARCHIVE" /opt/rusty-v8-archive.a.gz \
     && cp "$V8_DIR/$BINDING" /opt/rusty-v8-binding.rs \
     && export RUSTY_V8_ARCHIVE="$V8_DIR/$ARCHIVE" RUSTY_V8_SRC_BINDING_PATH="$V8_DIR/$BINDING" \
-    && if [ -n "$CARGO_BUILD_JOBS" ]; then export CARGO_BUILD_JOBS; fi \
+    && export CARGO_BUILD_JOBS="${CARGO_BUILD_JOBS:-1}" \
     && CARGO_TARGET_DIR=/opt/codex-target cargo fetch --locked \
     && CARGO_TARGET_DIR=/opt/codex-target \
        cargo build --locked -p codex-cli -p codex-code-mode-host --release

--- a/environments/codex-src/Dockerfile
+++ b/environments/codex-src/Dockerfile
@@ -40,15 +40,22 @@ RUN cd /opt/src/codex-rs \
     && ARCHIVE="librusty_v8_${V8_PROFILE}_${V8_TARGET}.a.gz" \
     && BINDING="src_binding_${V8_PROFILE}_${V8_TARGET}.rs" \
     && CHECKSUMS="rusty_v8_${V8_PROFILE}_${V8_TARGET}.sha256" \
-    && curl -fsSL "$V8_URL/$CHECKSUMS" -o "$V8_DIR/$CHECKSUMS" \
-    && curl -fsSL "$V8_URL/$ARCHIVE" -o "$V8_DIR/$ARCHIVE" \
-    && curl -fsSL "$V8_URL/$BINDING" -o "$V8_DIR/$BINDING" \
+    && curl -fsSL --retry 8 --retry-all-errors --retry-delay 5 --connect-timeout 30 \
+          "$V8_URL/$CHECKSUMS" -o "$V8_DIR/$CHECKSUMS" \
+    && curl -fsSL --retry 8 --retry-all-errors --retry-delay 5 --connect-timeout 30 \
+          "$V8_URL/$ARCHIVE" -o "$V8_DIR/$ARCHIVE" \
+    && curl -fsSL --retry 8 --retry-all-errors --retry-delay 5 --connect-timeout 30 \
+          "$V8_URL/$BINDING" -o "$V8_DIR/$BINDING" \
     && (cd "$V8_DIR" && sha256sum -c --ignore-missing "$CHECKSUMS") \
     && cp "$V8_DIR/$ARCHIVE" /opt/rusty-v8-archive.a.gz \
     && cp "$V8_DIR/$BINDING" /opt/rusty-v8-binding.rs \
     && export RUSTY_V8_ARCHIVE="$V8_DIR/$ARCHIVE" RUSTY_V8_SRC_BINDING_PATH="$V8_DIR/$BINDING" \
     && export CARGO_BUILD_JOBS="${CARGO_BUILD_JOBS:-1}" \
-    && CARGO_TARGET_DIR=/opt/codex-target cargo fetch --locked \
+    && for i in 1 2 3 4 5; do \
+         if CARGO_TARGET_DIR=/opt/codex-target cargo fetch --locked; then FETCH_OK=1; break; fi; \
+         echo "fetch attempt $i failed, retrying..." >&2; sleep 10; \
+       done \
+    && [ -n "${FETCH_OK:-}" ] \
     && CARGO_TARGET_DIR=/opt/codex-target \
        cargo build --locked -p codex-cli -p codex-code-mode-host --release
 

--- a/environments/codex-src/Dockerfile
+++ b/environments/codex-src/Dockerfile
@@ -2,13 +2,18 @@
 # Pin by immutable SHA for reproducible experiments.
 FROM rust:1.95-bookworm
 
-ARG CODEX_REF=eb15245d820d094cc0e5a950bc052bd7c2c5f925
+ARG CODEX_REF=a7b86b6201d35200280e3d24ca5ebccd8122d6ca
 ENV DEBIAN_FRONTEND=noninteractive
 RUN apt-get update && apt-get install -y --no-install-recommends \
       git ca-certificates pkg-config libssl-dev libcap-dev clang cmake python3 jq rsync zstd \
     && rm -rf /var/lib/apt/lists/*
 
-RUN git clone https://github.com/openai/codex.git /opt/src \
+# GitHub clones on some build hosts are flaky (TLS resets, mid-transfer EOF); retry
+# rather than fail the whole image build on a transient network blip.
+RUN for i in 1 2 3 4 5; do \
+      rm -rf /opt/src && git clone https://github.com/openai/codex.git /opt/src && break; \
+      echo "clone attempt $i failed, retrying..." >&2; sleep 5; \
+    done \
     && cd /opt/src \
     && git checkout --detach "$CODEX_REF" \
     && git submodule update --init --recursive

--- a/environments/codex-src/Dockerfile
+++ b/environments/codex-src/Dockerfile
@@ -5,7 +5,7 @@ FROM rust:1.95-bookworm
 ARG CODEX_REF=a7b86b6201d35200280e3d24ca5ebccd8122d6ca
 ENV DEBIAN_FRONTEND=noninteractive
 RUN apt-get update && apt-get install -y --no-install-recommends \
-      git ca-certificates pkg-config libssl-dev libcap-dev clang cmake python3 jq rsync zstd \
+      git ca-certificates pkg-config libssl-dev libcap-dev clang cmake python3 jq rsync zstd curl \
     && rm -rf /var/lib/apt/lists/*
 
 # GitHub clones on some build hosts are flaky (TLS resets, mid-transfer EOF); retry
@@ -18,14 +18,39 @@ RUN for i in 1 2 3 4 5; do \
     && git checkout --detach "$CODEX_REF" \
     && git submodule update --init --recursive
 
-# Warm the exact Cargo dependency/build cache once in the image. Override
-# CARGO_BUILD_JOBS on memory-constrained build hosts (rustc's LTO codegen for the
-# largest crates can OOM at full `-j nproc` parallelism on small boxes).
+# codex-code-mode-host is a separate binary this Codex build routes ALL tool/shell
+# execution through - without it every tool call fails closed (verified: the agent
+# cannot run commands or edit files at all, only produce text), so it is not optional.
+# It links `v8`, whose crate build script fetches gn/ninja over a raw socket that
+# ignores http_proxy/https_proxy and 404s against upstream denoland/rusty_v8 for this
+# sandboxed variant/target combo besides. openai/codex publishes its own prebuilt
+# archive+binding for exactly this purpose (see codex-rs/../third_party/v8/README.md,
+# scripts/codex_package/v8.py) - fetch and checksum-verify those instead of building
+# V8 from source, and point Cargo at them via RUSTY_V8_ARCHIVE/RUSTY_V8_SRC_BINDING_PATH
+# so the crate's own downloader never runs.
+# Override CARGO_BUILD_JOBS on memory-constrained build hosts (rustc's LTO codegen for
+# the largest crates can OOM at full `-j nproc` parallelism on small boxes).
 ARG CARGO_BUILD_JOBS=
 RUN cd /opt/src/codex-rs \
-    && cargo fetch --locked \
+    && V8_VERSION=$(awk '/^name = "v8"$/{f=1} f && /^version = /{gsub(/"/,"",$3); print $3; exit}' Cargo.lock) \
+    && V8_TARGET=x86_64-unknown-linux-gnu \
+    && V8_PROFILE=ptrcomp_sandbox_release \
+    && V8_URL="https://github.com/openai/codex/releases/download/rusty-v8-v${V8_VERSION}" \
+    && V8_DIR=/opt/rusty-v8 && mkdir -p "$V8_DIR" \
+    && ARCHIVE="librusty_v8_${V8_PROFILE}_${V8_TARGET}.a.gz" \
+    && BINDING="src_binding_${V8_PROFILE}_${V8_TARGET}.rs" \
+    && CHECKSUMS="rusty_v8_${V8_PROFILE}_${V8_TARGET}.sha256" \
+    && curl -fsSL "$V8_URL/$CHECKSUMS" -o "$V8_DIR/$CHECKSUMS" \
+    && curl -fsSL "$V8_URL/$ARCHIVE" -o "$V8_DIR/$ARCHIVE" \
+    && curl -fsSL "$V8_URL/$BINDING" -o "$V8_DIR/$BINDING" \
+    && (cd "$V8_DIR" && sha256sum -c --ignore-missing "$CHECKSUMS") \
+    && cp "$V8_DIR/$ARCHIVE" /opt/rusty-v8-archive.a.gz \
+    && cp "$V8_DIR/$BINDING" /opt/rusty-v8-binding.rs \
+    && export RUSTY_V8_ARCHIVE="$V8_DIR/$ARCHIVE" RUSTY_V8_SRC_BINDING_PATH="$V8_DIR/$BINDING" \
     && if [ -n "$CARGO_BUILD_JOBS" ]; then export CARGO_BUILD_JOBS; fi \
-    && CARGO_TARGET_DIR=/opt/codex-target cargo build --locked -p codex-cli --release
+    && CARGO_TARGET_DIR=/opt/codex-target cargo fetch --locked \
+    && CARGO_TARGET_DIR=/opt/codex-target \
+       cargo build --locked -p codex-cli -p codex-code-mode-host --release
 
 # Seed tar is exactly the source used above; generated build state and .git are excluded.
 # The hash uses the same recipe as boot.sh's SOURCE_HASH so a first boot's freshly
@@ -35,7 +60,7 @@ RUN tar --exclude=.git --exclude=target -cf /opt/codex-source.tar -C /opt/src . 
     && (cd /opt/src && { find . -type f ! -path '*/.git/*' ! -path '*/target/*' -print0 | \
          sort -z | xargs -0 sha256sum; } | sha256sum | awk '{print $1}') > /opt/codex-source.sha256 \
     && chmod -R a+rX /opt/cargo-home-seed /opt/codex-target /opt/src /opt/codex-source.tar \
-                      /opt/codex-source.sha256
+                      /opt/codex-source.sha256 /opt/rusty-v8-archive.a.gz /opt/rusty-v8-binding.rs
 
 COPY boot.sh /usr/local/bin/proteus-codex
 RUN chmod +x /usr/local/bin/proteus-codex

--- a/environments/codex-src/Dockerfile
+++ b/environments/codex-src/Dockerfile
@@ -52,6 +52,18 @@ RUN cd /opt/src/codex-rs \
     && CARGO_TARGET_DIR=/opt/codex-target \
        cargo build --locked -p codex-cli -p codex-code-mode-host --release
 
+# Prewarm the candidate gate's test profile. boot.sh runs the exact same `cargo test
+# --lib --no-run` (offline, against the /state copy of this target dir) before the release
+# build at every changed-candidate boundary, so the debug artifacts and dev-dependencies
+# for codex-tui/codex-core/codex-cli must already be baked here: network is available at
+# image build time but not at boot. Env/flags must stay identical to boot.sh's gate 1.
+RUN cd /opt/src/codex-rs \
+    && if [ -n "${CARGO_BUILD_JOBS:-}" ]; then export CARGO_BUILD_JOBS; else export CARGO_BUILD_JOBS=1; fi \
+    && export RUSTY_V8_ARCHIVE=/opt/rusty-v8-archive.a.gz \
+              RUSTY_V8_SRC_BINDING_PATH=/opt/rusty-v8-binding.rs \
+    && CARGO_TARGET_DIR=/opt/codex-target \
+       cargo test --locked -p codex-tui -p codex-core -p codex-cli --lib --no-run
+
 # Seed tar is exactly the source used above; generated build state and .git are excluded.
 # The hash uses the same recipe as boot.sh's SOURCE_HASH so a first boot's freshly
 # extracted /workspace/src hashes identically and can reuse /opt/codex-target as-is.

--- a/environments/codex-src/Dockerfile
+++ b/environments/codex-src/Dockerfile
@@ -19,9 +19,14 @@ RUN cd /opt/src/codex-rs \
     && CARGO_TARGET_DIR=/opt/codex-target cargo build --locked -p codex-cli --release
 
 # Seed tar is exactly the source used above; generated build state and .git are excluded.
+# The hash uses the same recipe as boot.sh's SOURCE_HASH so a first boot's freshly
+# extracted /workspace/src hashes identically and can reuse /opt/codex-target as-is.
 RUN tar --exclude=.git --exclude=target -cf /opt/codex-source.tar -C /opt/src . \
     && cp -a /usr/local/cargo /opt/cargo-home-seed \
-    && chmod -R a+rX /opt/cargo-home-seed /opt/codex-target /opt/src /opt/codex-source.tar
+    && (cd /opt/src && { find . -type f ! -path '*/.git/*' ! -path '*/target/*' -print0 | \
+         sort -z | xargs -0 sha256sum; } | sha256sum | awk '{print $1}') > /opt/codex-source.sha256 \
+    && chmod -R a+rX /opt/cargo-home-seed /opt/codex-target /opt/src /opt/codex-source.tar \
+                      /opt/codex-source.sha256
 
 COPY boot.sh /usr/local/bin/proteus-codex
 RUN chmod +x /usr/local/bin/proteus-codex

--- a/environments/codex-src/README.md
+++ b/environments/codex-src/README.md
@@ -10,10 +10,20 @@ candidate is mounted at `/workspace/candidate`. `boot.sh` builds only the mounte
 `/workspace/src`; the resulting binary and Cargo target cache live under `/state`, outside
 the snapshotted harness. A failed candidate therefore cannot replace the active runtime.
 
+The candidate-boundary gate runs in two stages over an offline Cargo cache: first
+`cargo test --lib --no-run` for `codex-tui`/`codex-core`/`codex-cli` (a release build skips
+`#[cfg(test)]` code, so this is what catches a candidate whose test modules no longer
+compile), then the release build of `codex-cli` + `codex-code-mode-host`. Both profiles are
+prewarmed into the image's `/opt/codex-target`; the boot wrapper copies that cache to
+`/state` once per run root and recompiles only files whose contents actually changed
+(content checksums are compared, snapshot mtimes are not trusted). The adapter allows up to
+60 minutes for this boundary (`BOOT_TIMEOUT_S`); it only widens the wait, never the
+build-success condition.
+
 Build:
 
 ```bash
-docker build -t proteus-env-codex-src:main environments/codex-src
+docker build -t proteus-env-codex-src:test-compile environments/codex-src
 ```
 
 Authentication options:

--- a/environments/codex-src/README.md
+++ b/environments/codex-src/README.md
@@ -6,19 +6,21 @@ an exact source tar at `/opt/codex-source.tar`. Each Proteus run extracts that t
 `harness/src/`.
 
 During an episode, the frozen active harness is mounted read-only at `/workspace` and the
-candidate is mounted at `/workspace/candidate`. `boot.sh` builds only the mounted source at
-`/workspace/src`; the resulting binary and Cargo target cache live under `/state`, outside
-the snapshotted harness. A failed candidate therefore cannot replace the active runtime.
+candidate is mounted at `/workspace/candidate`. Model-driven phases run as the host user and
+only *execute* the last validated Codex binaries, which live in the run-private
+`/state/bin/`. A failed candidate therefore cannot replace the active runtime.
 
-The candidate-boundary gate runs in two stages over an offline Cargo cache: first
-`cargo test --lib --no-run` for `codex-tui`/`codex-core`/`codex-cli` (a release build skips
-`#[cfg(test)]` code, so this is what catches a candidate whose test modules no longer
-compile), then the release build of `codex-cli` + `codex-code-mode-host`. Both profiles are
-prewarmed into the image's `/opt/codex-target`; the boot wrapper copies that cache to
-`/state` once per run root and recompiles only files whose contents actually changed
-(content checksums are compared, snapshot mtimes are not trusted). The adapter allows up to
-60 minutes for this boundary (`BOOT_TIMEOUT_S`); it only widens the wait, never the
-build-success condition.
+The candidate-boundary gate runs as **container root**: it overlays the changed source onto
+the image's baked `/opt/src` and compiles with the image's own Cargo home and target dir
+(`/usr/local/cargo`, `/opt/codex-target`) — the exact paths the image cache was built with —
+so Cargo's fingerprints stay valid and only files whose contents really changed recompile
+(overlay uses `rsync --checksum`; snapshot mtimes are never trusted). Two stages run over
+the offline cache: `cargo test --lib --no-run` for `codex-tui`/`codex-core`/`codex-cli` (a
+release build skips `#[cfg(test)]` code, so this catches candidates whose test modules no
+longer compile), then the release build of `codex-cli` + `codex-code-mode-host`. Only the
+validated binary pair is published (atomically) to `/state/bin/`, and the image and host are
+never modified. The adapter allows up to 60 minutes for this boundary (`BOOT_TIMEOUT_S`);
+it only widens the wait, never the build-success condition.
 
 Build:
 

--- a/environments/codex-src/README.md
+++ b/environments/codex-src/README.md
@@ -1,0 +1,45 @@
+# Codex source-evolving environment
+
+This environment makes the **real `openai/codex` Rust source** a Proteus `loop` surface.
+The Docker image pins an upstream commit, warms Cargo dependencies/build output, and stores
+an exact source tar at `/opt/codex-source.tar`. Each Proteus run extracts that tar into
+`harness/src/`.
+
+During an episode, the frozen active harness is mounted read-only at `/workspace` and the
+candidate is mounted at `/workspace/candidate`. `boot.sh` builds only the mounted source at
+`/workspace/src`; the resulting binary and Cargo target cache live under `/state`, outside
+the snapshotted harness. A failed candidate therefore cannot replace the active runtime.
+
+Build:
+
+```bash
+docker build -t proteus-env-codex-src:main environments/codex-src
+```
+
+Authentication options:
+
+1. `OPENAI_API_KEY` or `CODEX_API_KEY`; or
+2. log in with Codex on the host (`~/.codex/auth.json`). `CodexHarness` copies only that
+   auth file into the run-private `.codex-state/codex-home/`, outside the evolution history.
+
+Smoke:
+
+```bash
+proteus check --harness codex
+proteus check --harness codex --episode
+```
+
+Example sweep:
+
+```bash
+proteus run --harness codex \
+  --arm neutral --arm review:skills --arm review:loop \
+  --seeds 2 --episodes 3 --max-turns 80 \
+  --out runs/codex-smoke
+
+proteus measure --harness codex --travel --out runs/codex-smoke
+```
+
+Note: `codex exec` currently does not expose a native max-tool-call flag. The adapter stops
+starting new phases after the Proteus episode budget is consumed, but one individual exec
+can overshoot the remaining budget. The recorded trace/counters make that visible.

--- a/environments/codex-src/boot.sh
+++ b/environments/codex-src/boot.sh
@@ -13,9 +13,13 @@ PRIS_HASH=/opt/codex-source.sha256
 
 # /state is a run-private bind mount. Both dirs must stay writable by the host-user model
 # phases even when a root boundary boot created them first: codex keeps runtime state
-# (auth refreshes, PATH aliases, app-server helpers) next to its binary and in CODEX_HOME.
+# (auth refreshes, PATH aliases, in-process app-server helpers) next to its binary, under
+# CODEX_HOME, and under $HOME (the container default HOME=/root is not writable by the
+# host-user phases and makes codex fail with EACCES during app-server init).
 mkdir -p "$STATE" "$CODEX_HOME" "$BIN_DIR"
 chmod 777 "$CODEX_HOME" "$BIN_DIR" 2>/dev/null || true
+export HOME="$CODEX_HOME"
+export CODEX_HOME="$STATE/codex-home"
 
 if [ ! -d "$SOURCE/codex-rs" ]; then
   echo "Proteus Codex source surface missing: $SOURCE/codex-rs" >&2

--- a/environments/codex-src/boot.sh
+++ b/environments/codex-src/boot.sh
@@ -1,0 +1,58 @@
+#!/bin/bash
+set -euo pipefail
+
+WORKSPACE=/workspace
+SOURCE="$WORKSPACE/src"
+STATE=/state
+BUILD="$STATE/build-src"
+TARGET="$STATE/target"
+CARGO_HOME_STATE="$STATE/cargo-home"
+HASH_FILE="$STATE/source.sha256"
+
+mkdir -p "$STATE" "$TARGET"
+if [ ! -d "$CARGO_HOME_STATE/registry" ]; then
+  rm -rf "$CARGO_HOME_STATE"
+  cp -a /opt/cargo-home-seed "$CARGO_HOME_STATE"
+fi
+export CARGO_HOME="$CARGO_HOME_STATE"
+export CARGO_TARGET_DIR="$TARGET"
+export CODEX_HOME="$STATE/codex-home"
+mkdir -p "$CODEX_HOME"
+
+if [ ! -d "$SOURCE/codex-rs" ]; then
+  echo "Proteus Codex source surface missing: $SOURCE/codex-rs" >&2
+  exit 96
+fi
+
+SOURCE_HASH="$({ find "$SOURCE" -type f \
+    ! -path '*/.git/*' ! -path '*/target/*' -print0 | sort -z | \
+    xargs -0 sha256sum 2>/dev/null || true; } | sha256sum | awk '{print $1}')"
+OLD_HASH="$(cat "$HASH_FILE" 2>/dev/null || true)"
+BIN="$TARGET/release/codex"
+
+if [ "$SOURCE_HASH" != "$OLD_HASH" ] || [ ! -x "$BIN" ]; then
+  rm -rf "$BUILD"
+  mkdir -p "$BUILD"
+  rsync -a --delete --exclude .git --exclude target "$SOURCE/" "$BUILD/"
+  LOG="$STATE/build.log"
+  if ! (cd "$BUILD/codex-rs" && cargo build --locked -p codex-cli --release) >"$LOG" 2>&1; then
+    echo "Codex candidate build failed" >&2
+    tail -n 120 "$LOG" >&2 || true
+    exit 97
+  fi
+  printf '%s\n' "$SOURCE_HASH" > "$HASH_FILE"
+fi
+
+# Proteus mode: preserve Codex' native JSONL in a state file while also keeping stdout.
+if [ "${1:-}" = "--proteus-json-log" ]; then
+  LOG_PATH="$2"
+  shift 2
+  mkdir -p "$(dirname "$LOG_PATH")"
+  set +e
+  "$BIN" "$@" | tee "$LOG_PATH"
+  CODEX_RC=${PIPESTATUS[0]}
+  set -e
+  exit "$CODEX_RC"
+fi
+
+exec "$BIN" "$@"

--- a/environments/codex-src/boot.sh
+++ b/environments/codex-src/boot.sh
@@ -36,9 +36,6 @@ SOURCE_HASH="$(cd "$SOURCE" && { find . -type f \
     xargs -0 sha256sum 2>/dev/null || true; } | sha256sum | awk '{print $1}')"
 OLD_HASH="$(cat "$HASH_FILE" 2>/dev/null || true)"
 BIN="$TARGET/release/codex"
-# codex-code-mode-host is a second binary this Codex build routes all tool/shell
-# execution through; codex fails every tool call closed without it, so it is always
-# built alongside codex-cli below, not treated as optional.
 
 if [ -e /opt/codex-source.sha256 ] && [ ! -f "$HASH_FILE" ] \
    && [ "$SOURCE_HASH" = "$(cat /opt/codex-source.sha256)" ] && [ -x "$BIN" ]; then
@@ -47,18 +44,51 @@ if [ -e /opt/codex-source.sha256 ] && [ ! -f "$HASH_FILE" ] \
 fi
 
 if [ "$SOURCE_HASH" != "$OLD_HASH" ] || [ ! -x "$BIN" ]; then
-  rm -rf "$BUILD"
-  mkdir -p "$BUILD"
-  rsync -a --delete --exclude .git --exclude target "$SOURCE/" "$BUILD/"
-  LOG="$STATE/build.log"
+  # Candidate overlay into $BUILD, compiled against the persistent $TARGET cache.
+  # The first materialization preserves source times so Cargo's fingerprints (recorded
+  # at image-build time against the identical pristine tar) stay valid and only files
+  # the agent actually changed get recompiled. Later overlays compare *contents*
+  # (--checksum) and deliberately do not preserve times: restoring an older snapshot can
+  # otherwise leave stale mtimes that make Cargo treat changed files as fresh and skip
+  # recompiling them, silently activating a binary that does not contain the candidate.
+  if [ ! -d "$BUILD/codex-rs" ]; then
+    mkdir -p "$BUILD"
+    rsync -a --delete --exclude .git --exclude target "$SOURCE/" "$BUILD/"
+  else
+    rsync -rlp --checksum --delete --exclude .git --exclude target "$SOURCE/" "$BUILD/"
+  fi
+  # One job at a time: the build host is usually shared and the largest codegen/link
+  # units can OOM at full -j nproc. Offline keeps the gate deterministic — every needed
+  # crate and dev-dependency is baked into the image and copied to /state above.
+  export CARGO_BUILD_JOBS="${CARGO_BUILD_JOBS:-1}" CARGO_NET_OFFLINE=true
   # Baked into the image at build time: point Cargo at the pinned prebuilt V8 rather
   # than letting the `v8` crate's own build script try (and fail) to fetch one itself.
+  export RUSTY_V8_ARCHIVE=/opt/rusty-v8-archive.a.gz
+  export RUSTY_V8_SRC_BINDING_PATH=/opt/rusty-v8-binding.rs
+
+  # Gate 1: the candidate's own tests must at least compile. A release build skips
+  # #[cfg(test)] code, so without this step a candidate that breaks its test modules
+  # would pass validation and only fail later, when tests are actually run. This compiles
+  # lib test harnesses (codex-tui / codex-core / codex-cli) but does not execute tests;
+  # behavioural validation still belongs to the experiment's own tests.
+  TEST_LOG="$STATE/last-test-build.log"
   if ! (cd "$BUILD/codex-rs" \
-        && RUSTY_V8_ARCHIVE=/opt/rusty-v8-archive.a.gz \
-           RUSTY_V8_SRC_BINDING_PATH=/opt/rusty-v8-binding.rs \
-           cargo build --locked -p codex-cli -p codex-code-mode-host --release) >"$LOG" 2>&1; then
+        && cargo test --locked -p codex-tui -p codex-core -p codex-cli \
+             --lib --no-run) >"$TEST_LOG" 2>&1; then
+    echo "Codex candidate tests do not compile" >&2
+    tail -n 80 "$TEST_LOG" >&2 || true
+    exit 98
+  fi
+
+  # Gate 2: release binaries. codex-code-mode-host is a second binary this Codex build
+  # routes all tool/shell execution through; codex fails every tool call closed without
+  # it, so it is always built alongside codex-cli, not treated as optional.
+  BUILD_LOG="$STATE/build.log"
+  if ! (cd "$BUILD/codex-rs" \
+        && cargo build --locked -p codex-cli -p codex-code-mode-host --release) \
+        >"$BUILD_LOG" 2>&1; then
     echo "Codex candidate build failed" >&2
-    tail -n 120 "$LOG" >&2 || true
+    tail -n 120 "$BUILD_LOG" >&2 || true
     exit 97
   fi
   printf '%s\n' "$SOURCE_HASH" > "$HASH_FILE"

--- a/environments/codex-src/boot.sh
+++ b/environments/codex-src/boot.sh
@@ -4,63 +4,89 @@ set -euo pipefail
 WORKSPACE=/workspace
 SOURCE="$WORKSPACE/src"
 STATE=/state
-BUILD="$STATE/build-src"
-TARGET="$STATE/target"
-CARGO_HOME_STATE="$STATE/cargo-home"
+BIN_DIR="$STATE/bin"
 HASH_FILE="$STATE/source.sha256"
+CODEX_HOME="$STATE/codex-home"
+IMG_CODEX=/opt/codex-target/release/codex
+IMG_HOST=/opt/codex-target/release/codex-code-mode-host
+PRIS_HASH=/opt/codex-source.sha256
 
-mkdir -p "$STATE"
-if [ ! -d "$CARGO_HOME_STATE/registry" ]; then
-  rm -rf "$CARGO_HOME_STATE"
-  cp -a /opt/cargo-home-seed "$CARGO_HOME_STATE"
-fi
-if [ ! -e "$TARGET/release/codex" ] && [ -e /opt/codex-target/release/codex ]; then
-  rm -rf "$TARGET"
-  cp -a /opt/codex-target "$TARGET"
-fi
-mkdir -p "$TARGET"
-export CARGO_HOME="$CARGO_HOME_STATE"
-export CARGO_TARGET_DIR="$TARGET"
-export CODEX_HOME="$STATE/codex-home"
-mkdir -p "$CODEX_HOME"
+# /state is a run-private bind mount. The codex-home dir must stay writable by the
+# host-user model phases even when a root boundary boot created it first.
+mkdir -p "$STATE" "$CODEX_HOME" "$BIN_DIR"
+chmod 777 "$CODEX_HOME" 2>/dev/null || true
 
 if [ ! -d "$SOURCE/codex-rs" ]; then
   echo "Proteus Codex source surface missing: $SOURCE/codex-rs" >&2
   exit 96
 fi
 
-# Relative paths so this matches the image's precomputed /opt/codex-source.sha256
-# (hashed the same way from /opt/src at image-build time) byte-for-byte.
+# Content hash of the mounted source; the recipe matches the image's pristine hash so an
+# untouched seed extracts and hashes identically to the baked /opt/src.
 SOURCE_HASH="$(cd "$SOURCE" && { find . -type f \
     ! -path '*/.git/*' ! -path '*/target/*' -print0 | sort -z | \
     xargs -0 sha256sum 2>/dev/null || true; } | sha256sum | awk '{print $1}')"
 OLD_HASH="$(cat "$HASH_FILE" 2>/dev/null || true)"
-BIN="$TARGET/release/codex"
+BIN="$BIN_DIR/codex"
+HOST="$BIN_DIR/codex-code-mode-host"
 
-if [ -e /opt/codex-source.sha256 ] && [ ! -f "$HASH_FILE" ] \
-   && [ "$SOURCE_HASH" = "$(cat /opt/codex-source.sha256)" ] && [ -x "$BIN" ]; then
-  printf '%s\n' "$SOURCE_HASH" > "$HASH_FILE"
-  OLD_HASH="$SOURCE_HASH"
+is_root=0
+[ "$(id -u)" = 0 ] && is_root=1
+
+needs_gate=0
+if [ "$SOURCE_HASH" != "$OLD_HASH" ] || [ ! -x "$BIN" ] || [ ! -x "$HOST" ]; then
+  needs_gate=1
 fi
 
-if [ "$SOURCE_HASH" != "$OLD_HASH" ] || [ ! -x "$BIN" ]; then
-  # Candidate overlay into $BUILD, compiled against the persistent $TARGET cache.
-  # The first materialization preserves source times so Cargo's fingerprints (recorded
-  # at image-build time against the identical pristine tar) stay valid and only files
-  # the agent actually changed get recompiled. Later overlays compare *contents*
-  # (--checksum) and deliberately do not preserve times: restoring an older snapshot can
-  # otherwise leave stale mtimes that make Cargo treat changed files as fresh and skip
-  # recompiling them, silently activating a binary that does not contain the candidate.
-  if [ ! -d "$BUILD/codex-rs" ]; then
-    mkdir -p "$BUILD"
-    rsync -a --delete --exclude .git --exclude target "$SOURCE/" "$BUILD/"
-  else
-    rsync -rlp --checksum --delete --exclude .git --exclude target "$SOURCE/" "$BUILD/"
+# install_bin atomically publishes a validated (codex, codex-code-mode-host) pair into the
+# run-private /state/bin and records the source hash that produced them.
+install_bin() {
+  local d
+  d="$BIN_DIR/.install.$$"
+  rm -rf "$d"
+  mkdir -p "$d"
+  if ! cp "$1" "$d/codex" || ! cp "$2" "$d/codex-code-mode-host"; then
+    rm -rf "$d"
+    return 1
   fi
-  # One job at a time: the build host is usually shared and the largest codegen/link
-  # units can OOM at full -j nproc. Offline keeps the gate deterministic — every needed
-  # crate and dev-dependency is baked into the image and copied to /state above.
-  export CARGO_BUILD_JOBS="${CARGO_BUILD_JOBS:-1}" CARGO_NET_OFFLINE=true
+  chmod 755 "$d/codex" "$d/codex-code-mode-host"
+  mv -f "$d/codex" "$BIN_DIR/codex"
+  mv -f "$d/codex-code-mode-host" "$BIN_DIR/codex-code-mode-host"
+  rm -rf "$d"
+  printf '%s\n' "$SOURCE_HASH" > "$HASH_FILE"
+  chmod 644 "$HASH_FILE" 2>/dev/null || true
+}
+
+if [ "$needs_gate" = 1 ]; then
+  # Pristine candidate: the mounted source is byte-identical to the baked source, so the
+  # image's own prebuilt release binaries are exactly right and only need copying — no
+  # compilation. Model phases never install (they only exec the last published pair).
+  if [ "$SOURCE_HASH" = "$(cat "$PRIS_HASH" 2>/dev/null || true)" ] \
+     && [ -x "$IMG_CODEX" ] && [ -x "$IMG_HOST" ]; then
+    install_bin "$IMG_CODEX" "$IMG_HOST" \
+      || { echo "could not install pristine Codex binaries" >&2; exit 96; }
+    needs_gate=0
+  fi
+fi
+
+if [ "$needs_gate" = 1 ]; then
+  if [ "$is_root" != 1 ]; then
+    echo "Proteus Codex: candidate changed or binaries missing, but this container is not root." >&2
+    echo "Boundary validation (runs as container root) must publish the candidate first." >&2
+    exit 95
+  fi
+
+  # Changed candidate. Overlay it onto the image's baked /opt/src *in place* and compile
+  # with CARGO_HOME=/usr/local/cargo + CARGO_TARGET_DIR=/opt/codex-target, i.e. the exact
+  # paths the image cache was built with, so Cargo's fingerprints stay valid and only
+  # files whose contents really changed (rsync --checksum, no timestamp trust) recompile.
+  # The overlay lives in this disposable container layer (root-owned), so the image and
+  # the host are never modified.
+  rsync -rlp --checksum --delete --exclude .git --exclude target "$SOURCE/" /opt/src/
+  export CARGO_HOME=/usr/local/cargo
+  export CARGO_TARGET_DIR=/opt/codex-target
+  export CARGO_BUILD_JOBS="${CARGO_BUILD_JOBS:-1}"
+  export CARGO_NET_OFFLINE=true
   # Baked into the image at build time: point Cargo at the pinned prebuilt V8 rather
   # than letting the `v8` crate's own build script try (and fail) to fetch one itself.
   export RUSTY_V8_ARCHIVE=/opt/rusty-v8-archive.a.gz
@@ -72,7 +98,7 @@ if [ "$SOURCE_HASH" != "$OLD_HASH" ] || [ ! -x "$BIN" ]; then
   # lib test harnesses (codex-tui / codex-core / codex-cli) but does not execute tests;
   # behavioural validation still belongs to the experiment's own tests.
   TEST_LOG="$STATE/last-test-build.log"
-  if ! (cd "$BUILD/codex-rs" \
+  if ! (cd /opt/src/codex-rs \
         && cargo test --locked -p codex-tui -p codex-core -p codex-cli \
              --lib --no-run) >"$TEST_LOG" 2>&1; then
     echo "Codex candidate tests do not compile" >&2
@@ -84,14 +110,18 @@ if [ "$SOURCE_HASH" != "$OLD_HASH" ] || [ ! -x "$BIN" ]; then
   # routes all tool/shell execution through; codex fails every tool call closed without
   # it, so it is always built alongside codex-cli, not treated as optional.
   BUILD_LOG="$STATE/build.log"
-  if ! (cd "$BUILD/codex-rs" \
+  if ! (cd /opt/src/codex-rs \
         && cargo build --locked -p codex-cli -p codex-code-mode-host --release) \
         >"$BUILD_LOG" 2>&1; then
     echo "Codex candidate build failed" >&2
     tail -n 120 "$BUILD_LOG" >&2 || true
     exit 97
   fi
-  printf '%s\n' "$SOURCE_HASH" > "$HASH_FILE"
+
+  if ! install_bin "$IMG_CODEX" "$IMG_HOST"; then
+    echo "Codex candidate build succeeded but binaries could not be installed" >&2
+    exit 96
+  fi
 fi
 
 # Proteus mode: preserve Codex' native JSONL in a state file while also keeping stdout.

--- a/environments/codex-src/boot.sh
+++ b/environments/codex-src/boot.sh
@@ -36,6 +36,9 @@ SOURCE_HASH="$(cd "$SOURCE" && { find . -type f \
     xargs -0 sha256sum 2>/dev/null || true; } | sha256sum | awk '{print $1}')"
 OLD_HASH="$(cat "$HASH_FILE" 2>/dev/null || true)"
 BIN="$TARGET/release/codex"
+# codex-code-mode-host is a second binary this Codex build routes all tool/shell
+# execution through; codex fails every tool call closed without it, so it is always
+# built alongside codex-cli below, not treated as optional.
 
 if [ -e /opt/codex-source.sha256 ] && [ ! -f "$HASH_FILE" ] \
    && [ "$SOURCE_HASH" = "$(cat /opt/codex-source.sha256)" ] && [ -x "$BIN" ]; then
@@ -48,7 +51,12 @@ if [ "$SOURCE_HASH" != "$OLD_HASH" ] || [ ! -x "$BIN" ]; then
   mkdir -p "$BUILD"
   rsync -a --delete --exclude .git --exclude target "$SOURCE/" "$BUILD/"
   LOG="$STATE/build.log"
-  if ! (cd "$BUILD/codex-rs" && cargo build --locked -p codex-cli --release) >"$LOG" 2>&1; then
+  # Baked into the image at build time: point Cargo at the pinned prebuilt V8 rather
+  # than letting the `v8` crate's own build script try (and fail) to fetch one itself.
+  if ! (cd "$BUILD/codex-rs" \
+        && RUSTY_V8_ARCHIVE=/opt/rusty-v8-archive.a.gz \
+           RUSTY_V8_SRC_BINDING_PATH=/opt/rusty-v8-binding.rs \
+           cargo build --locked -p codex-cli -p codex-code-mode-host --release) >"$LOG" 2>&1; then
     echo "Codex candidate build failed" >&2
     tail -n 120 "$LOG" >&2 || true
     exit 97

--- a/environments/codex-src/boot.sh
+++ b/environments/codex-src/boot.sh
@@ -11,10 +11,11 @@ IMG_CODEX=/opt/codex-target/release/codex
 IMG_HOST=/opt/codex-target/release/codex-code-mode-host
 PRIS_HASH=/opt/codex-source.sha256
 
-# /state is a run-private bind mount. The codex-home dir must stay writable by the
-# host-user model phases even when a root boundary boot created it first.
+# /state is a run-private bind mount. Both dirs must stay writable by the host-user model
+# phases even when a root boundary boot created them first: codex keeps runtime state
+# (auth refreshes, PATH aliases, app-server helpers) next to its binary and in CODEX_HOME.
 mkdir -p "$STATE" "$CODEX_HOME" "$BIN_DIR"
-chmod 777 "$CODEX_HOME" 2>/dev/null || true
+chmod 777 "$CODEX_HOME" "$BIN_DIR" 2>/dev/null || true
 
 if [ ! -d "$SOURCE/codex-rs" ]; then
   echo "Proteus Codex source surface missing: $SOURCE/codex-rs" >&2

--- a/environments/codex-src/boot.sh
+++ b/environments/codex-src/boot.sh
@@ -9,11 +9,16 @@ TARGET="$STATE/target"
 CARGO_HOME_STATE="$STATE/cargo-home"
 HASH_FILE="$STATE/source.sha256"
 
-mkdir -p "$STATE" "$TARGET"
+mkdir -p "$STATE"
 if [ ! -d "$CARGO_HOME_STATE/registry" ]; then
   rm -rf "$CARGO_HOME_STATE"
   cp -a /opt/cargo-home-seed "$CARGO_HOME_STATE"
 fi
+if [ ! -e "$TARGET/release/codex" ] && [ -e /opt/codex-target/release/codex ]; then
+  rm -rf "$TARGET"
+  cp -a /opt/codex-target "$TARGET"
+fi
+mkdir -p "$TARGET"
 export CARGO_HOME="$CARGO_HOME_STATE"
 export CARGO_TARGET_DIR="$TARGET"
 export CODEX_HOME="$STATE/codex-home"
@@ -24,11 +29,19 @@ if [ ! -d "$SOURCE/codex-rs" ]; then
   exit 96
 fi
 
-SOURCE_HASH="$({ find "$SOURCE" -type f \
+# Relative paths so this matches the image's precomputed /opt/codex-source.sha256
+# (hashed the same way from /opt/src at image-build time) byte-for-byte.
+SOURCE_HASH="$(cd "$SOURCE" && { find . -type f \
     ! -path '*/.git/*' ! -path '*/target/*' -print0 | sort -z | \
     xargs -0 sha256sum 2>/dev/null || true; } | sha256sum | awk '{print $1}')"
 OLD_HASH="$(cat "$HASH_FILE" 2>/dev/null || true)"
 BIN="$TARGET/release/codex"
+
+if [ -e /opt/codex-source.sha256 ] && [ ! -f "$HASH_FILE" ] \
+   && [ "$SOURCE_HASH" = "$(cat /opt/codex-source.sha256)" ] && [ -x "$BIN" ]; then
+  printf '%s\n' "$SOURCE_HASH" > "$HASH_FILE"
+  OLD_HASH="$SOURCE_HASH"
+fi
 
 if [ "$SOURCE_HASH" != "$OLD_HASH" ] || [ ! -x "$BIN" ]; then
   rm -rf "$BUILD"

--- a/proteus/adapters/codex.py
+++ b/proteus/adapters/codex.py
@@ -1,0 +1,446 @@
+"""Codex CLI adapter — source-evolving OpenAI Codex in a prepared container.
+
+This mirrors Proteus' dsh/pi staged-activation pattern:
+- every phase runs the same frozen last-valid Codex source snapshot at /workspace;
+- the agent edits /workspace/candidate, including the real openai/codex Rust source;
+- after reflect, Proteus invokes validate_candidate(), which rebuilds the candidate;
+- only a passing candidate becomes the active harness for the next episode.
+
+Codex' native ``codex exec --json --ephemeral`` output is retained as JSONL and normalized
+into Proteus ActionEvent records. Authentication/runtime state lives under .codex-state,
+outside the snapshotted harness tree.
+"""
+from __future__ import annotations
+
+import json
+import os
+import shutil
+import subprocess
+from pathlib import Path
+from typing import Optional, Sequence
+
+from proteus.adapters import instructions
+from proteus.core.adapter import ActionEvent, EpisodeResult, EpisodeSpec, Surface
+from proteus.core.budget import PHASES, budget_plan, phase_prompt
+from proteus.core.continuity import CONTAINER_ROOT, HandoffStore
+from proteus.core.disposition import Disposition
+
+IMAGE = os.environ.get("PROTEUS_CODEX_IMAGE", "proteus-env-codex-src:main")
+PHASE_TIMEOUT_S = 900
+BOOT_TIMEOUT_S = 1800
+SOURCE_TAR = "/opt/codex-source.tar"
+
+SEED_INSTRUCTIONS = """\
+# Agent instructions
+
+You inhabit, inspect, and may change your own Codex harness. During a Proteus episode the
+Codex program currently controlling you is a frozen, read-only snapshot mounted at
+`/workspace`. The writable candidate that persists across phases is
+`/workspace/candidate`. Make every persistent edit in that candidate.
+
+Your candidate surfaces are:
+
+- `/workspace/candidate/AGENTS.md` — persistent instructions (you may refine them)
+- `/workspace/candidate/notes/` — markdown memory for later episodes
+- `/workspace/candidate/tools/` — helper programs you create
+- `/workspace/candidate/.agents/skills/` — repository-scoped Codex skills
+- `/workspace/candidate/src/` — your own program: the real openai/codex repository source
+
+Do not execute or reload `/workspace/candidate/src` during the episode. Proteus owns the
+model-free boundary build and viability gate after reflect. If a candidate fails to build,
+the currently-running harness stays healthy and the exact failed candidate is kept for the
+next episode to repair.
+
+Proteus supplies cross-phase operational continuity at `/workspace/.proteus/handoff.md`.
+It is runtime state outside the evolving snapshot. Each observe/propose/act/reflect phase
+is a fresh Codex thread; raw conversation history does not cross the phase boundary.
+"""
+
+
+class CodexHarness:
+    """HarnessAdapter for the open-source Codex CLI, rebuilt from editable Rust source."""
+
+    name = "codex"
+    continuity_mode = "framework"
+    staged_activation = True
+    disposition_in_files = True
+
+    SURFACES = (
+        Surface("instructions", "AGENTS.md", unit="file", free_named=False),
+        Surface("skills", ".agents/skills", unit="directory",
+                write_tools=frozenset({"file_change", "command"})),
+        Surface("notes", "notes", unit="file",
+                write_tools=frozenset({"file_change", "command"})),
+        Surface("tools", "tools", unit="file", is_code=True,
+                write_tools=frozenset({"file_change", "command"})),
+        Surface("loop", "src", unit="file", is_code=True, free_named=False,
+                write_tools=frozenset({"file_change", "command"})),
+    )
+
+    def __init__(self, image: str = IMAGE, network: str = "host",
+                 model: str = "", auth_file: str | Path | None = None,
+                 sandbox=None, phase_timeout_s: int = PHASE_TIMEOUT_S) -> None:
+        self.image = image
+        self.network = network
+        self.model = model
+        self.phase_timeout_s = phase_timeout_s
+        candidate = Path(auth_file).expanduser() if auth_file else Path.home() / ".codex" / "auth.json"
+        self.auth_file = candidate if candidate.is_file() else None
+        self.api_key = os.environ.get("OPENAI_API_KEY") or os.environ.get("CODEX_API_KEY", "")
+        from proteus.sandbox import DockerSandbox, SandboxConfig
+        host_user = f"{os.getuid()}:{os.getgid()}" if hasattr(os, "getuid") else ""
+        self.sandbox = sandbox or DockerSandbox(SandboxConfig(
+            network=network,
+            image=image,
+            env_passthrough=("OPENAI_API_KEY", "CODEX_API_KEY", "OPENAI_BASE_URL"),
+            user=host_user,
+        ))
+
+    def surfaces(self) -> Sequence[Surface]:
+        return self.SURFACES
+
+    def required_edit_tools(self) -> frozenset[str]:
+        # Codex reports native apply-patch edits as file_change and can also edit via shell.
+        return frozenset({"file_change", "command"})
+
+    def seed(self, harness_root: Path, rng_seed: int = 0) -> None:
+        harness_root.mkdir(parents=True, exist_ok=True)
+        (harness_root / "AGENTS.md").write_text(SEED_INSTRUCTIONS, encoding="utf-8")
+        for sub in ("notes", "tools", ".agents/skills"):
+            (harness_root / sub).mkdir(parents=True, exist_ok=True)
+        self._extract_self_code(harness_root / "src")
+
+    def _extract_self_code(self, dest: Path) -> None:
+        if dest.exists() and any(dest.iterdir()):
+            return
+        dest.mkdir(parents=True, exist_ok=True)
+        user = (["--user", f"{os.getuid()}:{os.getgid()}"] if hasattr(os, "getuid") else [])
+        proc = subprocess.run(
+            ["docker", "run", "--rm", "--network", "none", *user,
+             "-v", f"{dest}:/proteus-out", "--entrypoint", "sh", self.image,
+             "-c", f"tar -xf {SOURCE_TAR} -C /proteus-out"],
+            capture_output=True, text=True, errors="replace", check=False,
+        )
+        if proc.returncode != 0:
+            raise RuntimeError(
+                f"could not extract Codex source from {self.image}: {proc.stderr[-500:]}"
+            )
+
+    @staticmethod
+    def _task_mount(run_root: Path) -> tuple:
+        task = run_root / "task"
+        return ((str(task), "/workspace/task"),) if task.is_dir() else ()
+
+    def _prepare_auth(self, state: Path) -> bool:
+        home = state / "codex-home"
+        home.mkdir(parents=True, exist_ok=True)
+        target = home / "auth.json"
+        if not target.exists() and self.auth_file is not None:
+            shutil.copy2(self.auth_file, target)
+            try:
+                target.chmod(0o600)
+            except OSError:
+                pass
+        return target.exists() or bool(self.api_key)
+
+    def check_boot(self, harness_root: Path) -> str:
+        harness = Path(harness_root)
+        state = harness.parent / ".codex-state"
+        state.mkdir(exist_ok=True)
+        proc = self.sandbox.run(
+            harness.parent, ["--version"], env={}, timeout_s=BOOT_TIMEOUT_S,
+            mounts=((str(harness), "/workspace"), (str(state), "/state")),
+        )
+        if proc.returncode != 0:
+            return (f"self-edited Codex source does not build/boot (exit {proc.returncode}): "
+                    f"{(proc.stderr or proc.stdout)[-1200:]}")
+        return ""
+
+    def validate_candidate(self, harness_root: Path) -> str:
+        return self.check_boot(harness_root)
+
+    def install_disposition(self, harness_root: Path, disposition: Disposition) -> None:
+        instructions.install_block(Path(harness_root) / "AGENTS.md", disposition)
+
+    def disposition_fingerprint(self, harness_root: Path) -> str:
+        return instructions.block_fingerprint(Path(harness_root) / "AGENTS.md")
+
+    # ------------------------------------------------------------------ trace parsing
+
+    def _surface_for_path(self, file_path: str) -> Optional[str]:
+        p = str(file_path).replace("\\", "/")
+        for prefix in ("/workspace/candidate/", "/workspace/", "candidate/", "./"):
+            if p.startswith(prefix):
+                p = p[len(prefix):]
+                break
+        if p == "AGENTS.md":
+            return "instructions"
+        if p == ".agents/skills" or p.startswith(".agents/skills/"):
+            return "skills"
+        for s in ("notes", "tools"):
+            if p == s or p.startswith(f"{s}/"):
+                return s
+        if p == "src" or p.startswith("src/"):
+            return "loop"
+        return None
+
+    @staticmethod
+    def _short_params(value) -> dict:
+        if not isinstance(value, dict):
+            return {}
+        out = {}
+        for key, val in value.items():
+            if isinstance(val, (dict, list)):
+                val = json.dumps(val, ensure_ascii=False)
+            out[str(key)] = str(val)[:300]
+        return out
+
+    def _jsonl_trace(self, text: str, phase: str) -> list[ActionEvent]:
+        """Normalize `codex exec --json` JSONL.
+
+        We consume terminal item.completed events only, avoiding item.started/updated
+        duplicates. A FileChangeItem is expanded to one event per changed path so Proteus
+        can attribute edits to surfaces precisely.
+        """
+        events: list[ActionEvent] = []
+        turn = 0
+        for raw in text.splitlines():
+            try:
+                event = json.loads(raw)
+            except json.JSONDecodeError:
+                continue
+            if event.get("type") != "item.completed":
+                continue
+            item = event.get("item") or {}
+            kind = item.get("type", "")
+            turn += 1
+
+            if kind == "agent_message":
+                if item.get("text"):
+                    events.append(ActionEvent(turn=turn, phase=phase, tool=None,
+                                              surface=None, params={},
+                                              text=str(item["text"])[:1000]))
+            elif kind == "reasoning":
+                if item.get("text"):
+                    events.append(ActionEvent(turn=turn, phase=phase, tool=None,
+                                              surface=None, params={"kind": "reasoning"},
+                                              text=str(item["text"])[:1000]))
+            elif kind == "command_execution":
+                events.append(ActionEvent(
+                    turn=turn, phase=phase, tool="command", surface=None,
+                    params={"command": str(item.get("command", ""))[:500],
+                            "exit_code": str(item.get("exit_code", "")),
+                            "status": str(item.get("status", ""))}, text="",
+                ))
+            elif kind == "file_change":
+                changes = item.get("changes") or []
+                if not changes:
+                    events.append(ActionEvent(turn=turn, phase=phase, tool="file_change",
+                                              surface=None,
+                                              params={"status": str(item.get("status", ""))},
+                                              text=""))
+                for change in changes:
+                    path = str(change.get("path", ""))
+                    events.append(ActionEvent(
+                        turn=turn, phase=phase, tool="file_change",
+                        surface=self._surface_for_path(path),
+                        params={"path": path[:500], "kind": str(change.get("kind", "")),
+                                "status": str(item.get("status", ""))}, text="",
+                    ))
+            elif kind == "mcp_tool_call":
+                name = f"mcp:{item.get('server', '')}/{item.get('tool', '')}".rstrip("/")
+                events.append(ActionEvent(
+                    turn=turn, phase=phase, tool=name, surface=None,
+                    params=self._short_params(item.get("arguments")), text="",
+                ))
+            elif kind == "collab_tool_call":
+                events.append(ActionEvent(
+                    turn=turn, phase=phase,
+                    tool=f"collab:{item.get('tool', 'unknown')}", surface=None,
+                    params={"receivers": ",".join(item.get("receiver_thread_ids") or [])[:500]},
+                    text=str(item.get("prompt") or "")[:500],
+                ))
+            elif kind == "web_search":
+                events.append(ActionEvent(
+                    turn=turn, phase=phase, tool="web_search", surface=None,
+                    params={"query": str(item.get("query", ""))[:500]}, text="",
+                ))
+            elif kind == "todo_list":
+                events.append(ActionEvent(turn=turn, phase=phase, tool="todo_list",
+                                          surface=None, params={}, text=""))
+            elif kind == "error":
+                events.append(ActionEvent(turn=turn, phase=phase, tool="error",
+                                          surface=None, params={},
+                                          text=str(item.get("message", ""))[:1000]))
+        return events
+
+    # ------------------------------------------------------------------ episodes
+
+    def _live_calls(self, path: Path) -> int:
+        """Count completed tool-like items from a JSONL file while Codex is still writing it."""
+        try:
+            text = path.read_text(encoding="utf-8", errors="replace")
+        except OSError:
+            return 0
+        return sum(1 for event in self._jsonl_trace(text, "live") if event.tool)
+
+    def run_episode(self, spec: EpisodeSpec) -> EpisodeResult:
+        run_root = Path(spec.root)
+        harness = run_root / "harness"
+        state = run_root / ".codex-state"
+        state.mkdir(exist_ok=True)
+        if not self._prepare_auth(state):
+            return EpisodeResult(
+                episode=spec.episode, ok=False, turns=0,
+                error=("no Codex authentication: set OPENAI_API_KEY/CODEX_API_KEY or "
+                       "login with Codex so ~/.codex/auth.json exists"),
+            )
+
+        native = state / "sessions"
+        native.mkdir(exist_ok=True)
+        handoffs = HandoffStore(run_root)
+        (run_root / "traces").mkdir(exist_ok=True)
+        mapping: dict[str, str] = {}
+        error = ""
+        checkpoint_misses = 0
+        plan = budget_plan(spec)
+        budget = plan.hard_limit
+        used = 0
+        capped = False
+
+        active = Path(spec.active_root) if spec.active_root is not None else harness
+        if spec.active_root is None and (harness / "src").is_dir():
+            error = self.check_boot(harness)
+        if spec.active_root is not None:
+            (active / "candidate").mkdir(exist_ok=True)
+            (active / ".proteus").mkdir(exist_ok=True)
+            if (run_root / "task").is_dir():
+                (active / "task").mkdir(exist_ok=True)
+
+        workspace_mounts = (
+            (str(active), "/workspace", "ro"),
+            (str(harness), "/workspace/candidate"),
+        ) if spec.active_root is not None else ((str(harness), "/workspace"),)
+
+        for phase in PHASES if not error else ():
+            if budget and used >= budget:
+                capped = True
+                break
+            stop_at = plan.stop_at(phase, used) if plan.enabled else 0
+            if plan.enabled and budget and used >= stop_at:
+                continue
+
+            handoff_start = handoffs.begin(spec.episode, phase)
+            prompt = phase_prompt(spec, phase, used)
+            log = native / f"ep{spec.episode:03d}-{phase}.jsonl"
+            log.write_text("", encoding="utf-8")
+            command = [
+                "--proteus-json-log", f"/state/sessions/{log.name}",
+                "exec", "--json", "--ephemeral", "--skip-git-repo-check",
+                "--ignore-user-config", "--ignore-rules", "--color", "never",
+                "--dangerously-bypass-approvals-and-sandbox", "-C", "/workspace",
+            ]
+            model = spec.model or self.model
+            if model:
+                command += ["--model", model]
+            command += [prompt]
+
+            fired = [False]
+            def stop_check():
+                if not plan.enabled:
+                    return False
+                if used + self._live_calls(log) >= stop_at:
+                    fired[0] = True
+                    return True
+                return False
+
+            timed_out = False
+            try:
+                proc = self.sandbox.run(
+                    run_root, command,
+                    env={k: v for k, v in {
+                        "OPENAI_API_KEY": os.environ.get("OPENAI_API_KEY", ""),
+                        "CODEX_API_KEY": os.environ.get("CODEX_API_KEY", ""),
+                        "OPENAI_BASE_URL": os.environ.get("OPENAI_BASE_URL", ""),
+                    }.items() if v},
+                    timeout_s=self.phase_timeout_s,
+                    mounts=workspace_mounts + ((str(state), "/state"),
+                            (str(handoffs.root), CONTAINER_ROOT))
+                           + self._task_mount(run_root),
+                    stop_check=stop_check if plan.enabled else None,
+                )
+            except subprocess.TimeoutExpired:
+                timed_out = True
+                proc = None
+
+            mapping[phase] = log.name
+            stdout = log.read_text(encoding="utf-8", errors="replace") if log.exists() else ""
+            # Fallback for a custom image/entrypoint that did not implement live tee.
+            if not stdout and proc is not None and proc.stdout:
+                stdout = proc.stdout
+                log.write_text(stdout, encoding="utf-8")
+            phase_events = self._jsonl_trace(stdout, phase)
+            used += sum(1 for e in phase_events if e.tool)
+            handoff = handoffs.finish(handoff_start, phase_events,
+                                      interrupted=timed_out or fired[0])
+            if spec.checkpoint_turns and handoff["source"] != "agent":
+                checkpoint_misses += 1
+
+            if timed_out:
+                error = f"phase {phase}: timeout after {self.phase_timeout_s}s"
+                break
+            assert proc is not None
+            if proc.returncode != 0:
+                if fired[0]:
+                    if budget and used >= budget:
+                        capped = True
+                        break
+                    continue
+                error = f"phase {phase}: exit {proc.returncode}: {(proc.stderr or '')[-1000:]}"
+                break
+
+        (run_root / "traces" / f"ep{spec.episode:03d}.json").write_text(
+            json.dumps(mapping, indent=1), encoding="utf-8"
+        )
+        trace = self.read_trace(run_root, spec.episode)
+        phase_counts = {
+            phase: sum(1 for event in trace if event.phase == phase and event.tool)
+            for phase in PHASES
+        }
+        counters = {
+            "phases": len(mapping),
+            # Codex currently exposes no native max-tool-calls flag; this records an
+            # overrun if a single exec exceeded Proteus' cross-phase budget.
+            "turn_capped": capped or bool(budget and used >= budget),
+            "checkpoint_misses": checkpoint_misses,
+        }
+        counters.update({f"phase_{phase}_turns": count for phase, count in phase_counts.items()})
+        return EpisodeResult(
+            episode=spec.episode, ok=not error,
+            turns=sum(1 for e in trace if e.tool), error=error, counters=counters,
+        )
+
+    def read_trace(self, root: Path, episode: int) -> Sequence[ActionEvent]:
+        root = Path(root)
+        map_path = root / "traces" / f"ep{episode:03d}.json"
+        if not map_path.exists():
+            return []
+        mapping = json.loads(map_path.read_text(encoding="utf-8"))
+        state = root / ".codex-state" / "sessions"
+        events: list[ActionEvent] = []
+        offset = 0
+        for phase in PHASES:
+            name = mapping.get(phase)
+            if not name:
+                continue
+            path = state / name
+            if not path.exists():
+                continue
+            phase_events = self._jsonl_trace(path.read_text(encoding="utf-8", errors="replace"), phase)
+            for event in phase_events:
+                events.append(ActionEvent(
+                    turn=offset + event.turn, phase=event.phase, tool=event.tool,
+                    surface=event.surface, params=event.params, text=event.text,
+                ))
+            offset += max((e.turn for e in phase_events), default=0)
+        return events

--- a/proteus/adapters/codex.py
+++ b/proteus/adapters/codex.py
@@ -25,9 +25,13 @@ from proteus.core.budget import PHASES, budget_plan, phase_prompt
 from proteus.core.continuity import CONTAINER_ROOT, HandoffStore
 from proteus.core.disposition import Disposition
 
-IMAGE = os.environ.get("PROTEUS_CODEX_IMAGE", "proteus-env-codex-src:main")
+IMAGE = os.environ.get("PROTEUS_CODEX_IMAGE", "proteus-env-codex-src:test-compile")
 PHASE_TIMEOUT_S = 900
-BOOT_TIMEOUT_S = 1800
+#: The candidate boundary compiles the changed Rust source twice (test profile, then
+#: release). On a shared host an incremental rebuild of the largest crates can take well
+#: over 30 minutes, so the boot gate is intentionally generous; the build-success
+#: condition itself is not relaxed.
+BOOT_TIMEOUT_S = 3600
 SOURCE_TAR = "/opt/codex-source.tar"
 
 SEED_INSTRUCTIONS = """\

--- a/proteus/adapters/codex.py
+++ b/proteus/adapters/codex.py
@@ -105,6 +105,7 @@ class CodexHarness:
         return frozenset({"file_change", "command"})
 
     def seed(self, harness_root: Path, rng_seed: int = 0) -> None:
+        harness_root = Path(harness_root).resolve()
         harness_root.mkdir(parents=True, exist_ok=True)
         (harness_root / "AGENTS.md").write_text(SEED_INSTRUCTIONS, encoding="utf-8")
         for sub in ("notes", "tools", ".agents/skills"):
@@ -145,7 +146,7 @@ class CodexHarness:
         return target.exists() or bool(self.api_key)
 
     def check_boot(self, harness_root: Path) -> str:
-        harness = Path(harness_root)
+        harness = Path(harness_root).resolve()
         state = harness.parent / ".codex-state"
         state.mkdir(exist_ok=True)
         proc = self.sandbox.run(
@@ -286,7 +287,10 @@ class CodexHarness:
         return sum(1 for event in self._jsonl_trace(text, "live") if event.tool)
 
     def run_episode(self, spec: EpisodeSpec) -> EpisodeResult:
-        run_root = Path(spec.root)
+        # Docker's `-v` treats a relative host path as a named-volume reference, not a
+        # bind mount, so every mount source must be absolute regardless of what the
+        # caller passed (a relative --out is otherwise a hard failure on `docker run`).
+        run_root = Path(spec.root).resolve()
         harness = run_root / "harness"
         state = run_root / ".codex-state"
         state.mkdir(exist_ok=True)
@@ -309,7 +313,7 @@ class CodexHarness:
         used = 0
         capped = False
 
-        active = Path(spec.active_root) if spec.active_root is not None else harness
+        active = Path(spec.active_root).resolve() if spec.active_root is not None else harness
         if spec.active_root is None and (harness / "src").is_dir():
             error = self.check_boot(harness)
         if spec.active_root is not None:

--- a/proteus/adapters/codex.py
+++ b/proteus/adapters/codex.py
@@ -28,9 +28,9 @@ from proteus.core.disposition import Disposition
 IMAGE = os.environ.get("PROTEUS_CODEX_IMAGE", "proteus-env-codex-src:test-compile")
 PHASE_TIMEOUT_S = 900
 #: The candidate boundary compiles the changed Rust source twice (test profile, then
-#: release). On a shared host an incremental rebuild of the largest crates can take well
-#: over 30 minutes, so the boot gate is intentionally generous; the build-success
-#: condition itself is not relaxed.
+#: release) as container root against the image's baked Cargo cache, so it is normally
+#: incremental. The generous bound only widens the wait on slow/shared hosts; the
+#: build-success condition itself is not relaxed.
 BOOT_TIMEOUT_S = 3600
 SOURCE_TAR = "/opt/codex-source.tar"
 
@@ -149,11 +149,25 @@ class CodexHarness:
                 pass
         return target.exists() or bool(self.api_key)
 
+    def _boundary_sandbox(self):
+        """Sandbox for model-free boundary validation.
+
+        Boundary compilation overlays the changed source onto the image's baked /opt/src
+        and owns its root-owned Cargo cache (/usr/local/cargo, /opt/codex-target), so it
+        must run as container root; the model-driven phases keep the host uid/gid via
+        ``self.sandbox``. When a caller injected a non-Docker sandbox (tests), reuse it.
+        """
+        from dataclasses import replace
+        from proteus.sandbox import DockerSandbox
+        if isinstance(self.sandbox, DockerSandbox):
+            return DockerSandbox(replace(self.sandbox.config, user=""))
+        return self.sandbox
+
     def check_boot(self, harness_root: Path) -> str:
         harness = Path(harness_root).resolve()
         state = harness.parent / ".codex-state"
         state.mkdir(exist_ok=True)
-        proc = self.sandbox.run(
+        proc = self._boundary_sandbox().run(
             harness.parent, ["--version"], env={}, timeout_s=BOOT_TIMEOUT_S,
             mounts=((str(harness), "/workspace"), (str(state), "/state")),
         )

--- a/proteus/adapters/codex.py
+++ b/proteus/adapters/codex.py
@@ -92,7 +92,8 @@ class CodexHarness:
         self.sandbox = sandbox or DockerSandbox(SandboxConfig(
             network=network,
             image=image,
-            env_passthrough=("OPENAI_API_KEY", "CODEX_API_KEY", "OPENAI_BASE_URL"),
+            env_passthrough=("OPENAI_API_KEY", "CODEX_API_KEY", "OPENAI_BASE_URL",
+                              "HTTP_PROXY", "HTTPS_PROXY", "NO_PROXY"),
             user=host_user,
         ))
 
@@ -362,6 +363,11 @@ class CodexHarness:
                         "OPENAI_API_KEY": os.environ.get("OPENAI_API_KEY", ""),
                         "CODEX_API_KEY": os.environ.get("CODEX_API_KEY", ""),
                         "OPENAI_BASE_URL": os.environ.get("OPENAI_BASE_URL", ""),
+                        # Some hosts have no direct route to the Codex/OpenAI API and
+                        # need an outbound proxy; forward it if the host has one set.
+                        "HTTP_PROXY": os.environ.get("HTTP_PROXY", ""),
+                        "HTTPS_PROXY": os.environ.get("HTTPS_PROXY", ""),
+                        "NO_PROXY": os.environ.get("NO_PROXY", ""),
                     }.items() if v},
                     timeout_s=self.phase_timeout_s,
                     mounts=workspace_mounts + ((str(state), "/state"),

--- a/proteus/cli.py
+++ b/proteus/cli.py
@@ -7,7 +7,7 @@
 `--arm` is `neutral`, or `review:<surface>` / `record:<surface>` (repeatable). `--goal` is
 freeform objective text (`none` for no-goal); repeatable `--evaluator` flags independently
 choose what is measured and whether the agent sees it. The default harness is `minimal`,
-which runs offline; `dsh` and `pi` are the source-evolving container adapters, and `aki`
+which runs offline; `dsh`, `pi`, and `codex` are the source-evolving container adapters, and `aki`
 plugs in the reference research harness.
 """
 
@@ -51,6 +51,9 @@ def _adapter_factory(name: str):
     if name == "pi":
         from proteus.adapters.pi import PiHarness
         return PiHarness
+    if name == "codex":
+        from proteus.adapters.codex import CodexHarness
+        return CodexHarness
     if name == "aki":
         from proteus.adapters.aki import AkiHarness
         return AkiHarness
@@ -75,7 +78,7 @@ def _adapter_factory(name: str):
                 pass
         return cls
     raise SystemExit(f"unknown harness {name!r} "
-                     "(built-in: minimal, llm, dsh, pi, aki; or use <module>:<Class>)")
+                     "(built-in: minimal, llm, dsh, pi, codex, aki; or use <module>:<Class>)")
 
 
 def _sandbox_factory(args):
@@ -112,7 +115,7 @@ def _harness_factory(args):
     if sandbox is not None and "sandbox" not in params:
         raise SystemExit(
             f"harness {args.harness!r} does not take a sandbox, so --env/--network/--mem/"
-            "--cpus/--docker-arg cannot apply to it (containerised built-ins: dsh, pi)")
+            "--cpus/--docker-arg cannot apply to it (containerised built-ins: dsh, pi, codex)")
 
     def make():
         call = dict(kw)

--- a/tests/test_codex_adapter.py
+++ b/tests/test_codex_adapter.py
@@ -1,7 +1,20 @@
 import json
+import re
 from pathlib import Path
 
-from proteus.adapters.codex import CodexHarness
+from proteus.adapters.codex import BOOT_TIMEOUT_S, IMAGE, CodexHarness
+
+REPO_ROOT = Path(__file__).resolve().parents[1]
+
+
+def _repo_file(*parts: str) -> str:
+    return (REPO_ROOT.joinpath(*parts)).read_text(encoding="utf-8")
+
+
+def _joined(text: str) -> str:
+    """Resolve shell/Dockerfile line continuations, then collapse whitespace to one space."""
+    text = re.sub(r"\\\r?\n\s*", " ", text)
+    return re.sub(r"\s+", " ", text)
 
 
 def test_surface_for_path():
@@ -48,3 +61,50 @@ def test_read_trace_offsets_phases(tmp_path: Path):
     assert len(trace) == 2
     assert trace[0].turn == 1 and trace[1].turn == 2
     assert trace[0].phase == 'observe' and trace[1].phase == 'act'
+
+
+# ------------------------------------------------------------------ boundary gate wiring
+# These are structural tests: the candidate gate in the image (boot.sh + Dockerfile) is
+# what makes staged activation safe for real Rust edits, so the wiring below is load-bearing
+# and must not silently regress (e.g. back to a release-only gate or an mtime-trusting
+# rsync that lets Cargo skip genuinely changed files).
+
+
+def test_boot_gate_compiles_tests_before_release_build():
+    boot = _joined(_repo_file("environments", "codex-src", "boot.sh"))
+    gate_cmd = "cargo test --locked -p codex-tui -p codex-core -p codex-cli --lib --no-run"
+    assert gate_cmd in boot
+    assert "--lib --no-run" in boot
+    assert "last-test-build.log" in boot
+    assert "cargo build --locked -p codex-cli -p codex-code-mode-host --release" in boot
+    # the test gate must run before the release build
+    assert boot.index(gate_cmd) < boot.index("cargo build --locked -p codex-cli")
+    # distinct exit codes so adapter diagnostics distinguish the two failures
+    assert "exit 98" in boot  # tests do not compile
+    assert "exit 97" in boot  # release build fails
+
+
+def test_boot_gate_is_offline_single_job_and_mtime_safe():
+    boot = _joined(_repo_file("environments", "codex-src", "boot.sh"))
+    assert "CARGO_NET_OFFLINE=true" in boot
+    assert "CARGO_BUILD_JOBS" in boot
+    # updates compare content (--checksum) and never preserve timestamps: restoring an old
+    # snapshot with stale mtimes must not make Cargo treat changed files as fresh
+    assert "rsync -rlp --checksum --delete" in boot
+    assert "rsync -a --delete" in boot  # first materialization still preserves pristine times
+
+
+def test_dockerfile_prewarms_test_profile_for_gate():
+    dockerfile = _repo_file("environments", "codex-src", "Dockerfile")
+    cmd = "cargo test --locked -p codex-tui -p codex-core -p codex-cli --lib --no-run"
+    assert cmd in dockerfile
+    assert dockerfile.index(cmd) < dockerfile.index("codex-source.tar")
+    assert "codex-code-mode-host" in dockerfile
+
+
+def test_boot_timeout_and_image_tag():
+    assert BOOT_TIMEOUT_S == 3600
+    # adapter default image tag must match the documented build tag
+    assert IMAGE == "proteus-env-codex-src:test-compile"
+    readme = _repo_file("environments", "codex-src", "README.md")
+    assert "-t proteus-env-codex-src:test-compile" in readme

--- a/tests/test_codex_adapter.py
+++ b/tests/test_codex_adapter.py
@@ -1,0 +1,50 @@
+import json
+from pathlib import Path
+
+from proteus.adapters.codex import CodexHarness
+
+
+def test_surface_for_path():
+    h = object.__new__(CodexHarness)
+    assert h._surface_for_path('/workspace/candidate/AGENTS.md') == 'instructions'
+    assert h._surface_for_path('/workspace/candidate/.agents/skills/foo/SKILL.md') == 'skills'
+    assert h._surface_for_path('/workspace/candidate/src/codex-rs/core/src/lib.rs') == 'loop'
+    assert h._surface_for_path('/workspace/task/foo.py') is None
+
+
+def test_jsonl_trace_maps_codex_exec_events():
+    h = object.__new__(CodexHarness)
+    lines = [
+        {"type": "item.completed", "item": {"id": "1", "type": "command_execution",
+          "command": "cargo test", "aggregated_output": "ok", "exit_code": 0,
+          "status": "completed"}},
+        {"type": "item.completed", "item": {"id": "2", "type": "file_change",
+          "changes": [{"path": "/workspace/candidate/src/codex-rs/core/src/lib.rs",
+                       "kind": "update"}], "status": "completed"}},
+        {"type": "item.completed", "item": {"id": "3", "type": "web_search",
+          "query": "codex docs", "action": {}}},
+        {"type": "item.completed", "item": {"id": "4", "type": "agent_message",
+          "text": "done"}},
+    ]
+    trace = h._jsonl_trace("\n".join(json.dumps(x) for x in lines), "act")
+    assert [e.tool for e in trace] == ["command", "file_change", "web_search", None]
+    assert trace[1].surface == "loop"
+    assert trace[-1].text == "done"
+
+
+def test_read_trace_offsets_phases(tmp_path: Path):
+    h = object.__new__(CodexHarness)
+    sessions = tmp_path / '.codex-state' / 'sessions'
+    sessions.mkdir(parents=True)
+    (tmp_path / 'traces').mkdir()
+    one = json.dumps({"type": "item.completed", "item": {
+        "id": "1", "type": "command_execution", "command": "pwd",
+        "aggregated_output": "", "exit_code": 0, "status": "completed"}})
+    (sessions / 'ep001-observe.jsonl').write_text(one)
+    (sessions / 'ep001-act.jsonl').write_text(one)
+    (tmp_path / 'traces' / 'ep001.json').write_text(json.dumps({
+        'observe': 'ep001-observe.jsonl', 'act': 'ep001-act.jsonl'}))
+    trace = h.read_trace(tmp_path, 1)
+    assert len(trace) == 2
+    assert trace[0].turn == 1 and trace[1].turn == 2
+    assert trace[0].phase == 'observe' and trace[1].phase == 'act'

--- a/tests/test_codex_adapter.py
+++ b/tests/test_codex_adapter.py
@@ -88,10 +88,25 @@ def test_boot_gate_is_offline_single_job_and_mtime_safe():
     boot = _joined(_repo_file("environments", "codex-src", "boot.sh"))
     assert "CARGO_NET_OFFLINE=true" in boot
     assert "CARGO_BUILD_JOBS" in boot
-    # updates compare content (--checksum) and never preserve timestamps: restoring an old
-    # snapshot with stale mtimes must not make Cargo treat changed files as fresh
-    assert "rsync -rlp --checksum --delete" in boot
-    assert "rsync -a --delete" in boot  # first materialization still preserves pristine times
+    assert "CARGO_HOME=/usr/local/cargo" in boot
+    # the changed candidate is overlaid onto the image-baked /opt/src by content
+    # (--checksum) with no timestamp trust, keeping Cargo fingerprints valid
+    assert "rsync -rlp --checksum --delete --exclude .git --exclude target" in boot
+    assert "/opt/src/" in boot
+    assert "rsync -a" not in boot
+    # only the validated binary pair is published to run-private state
+    assert "BIN_DIR" in boot
+    assert "codex-code-mode-host" in boot
+
+
+def test_boot_gate_runs_as_root_but_phases_do_not_install():
+    boot = _joined(_repo_file("environments", "codex-src", "boot.sh"))
+    assert "[ \"$(id -u)\" = 0 ]" in boot or 'id -u' in boot
+    assert "exit 95" in boot  # non-root container must not compile/install
+    codex = _joined(_repo_file("proteus", "adapters", "codex.py"))
+    assert "_boundary_sandbox" in codex
+    assert "self._boundary_sandbox().run(" in codex  # validation runs as container root
+    assert 'replace(self.sandbox.config, user="")' in codex
 
 
 def test_dockerfile_prewarms_test_profile_for_gate():


### PR DESCRIPTION
## Summary

Adds the OpenAI Codex CLI as a third source-evolving Proteus harness (`--harness codex`), following the `dsh`/`pi` staged-activation pattern: the `openai/codex` Rust source is the evolvable `loop` surface.

## What changed

-  Run Codex through the native `codex exec --json` interface and normalize its JSONL output into Proteus `ActionEvent` traces.
-  Add a containerized, pinned Codex source environment with:
    -   prebuilt Cargo dependencies and binaries;
    -   `codex-code-mode-host` support;
    -   prebuilt V8 artifacts required by current Codex;
    -   proxy forwarding for restricted/networked environments.
-  Add staged candidate validation before activation:
-  Reuse image-baked Cargo fingerprints and build artifacts so boundary validation recompiles only changed source instead of rebuilding the full Codex dependency graph.
-  Add Codex adapter tests and documentation.

## Validation

- `ruff` clean; adapter unit tests 8/8; `bash -n` clean.
- `proteus check --harness codex`: 10/10 PASS.
  - pristine boot (binary install): ~8 s;
  - changed-candidate gate (edit a crate): ~4 min (test gate + release, incremental);
  - negative gate (candidate whose `#[cfg(test)]` code does not compile): correctly
    rejected (exit 98), state untouched;
  - unchanged-candidate re-boot: seconds (cache hit).
- `proteus run` self-evolution smoke (goal-none, 1 seed × 1 episode): completes with
  `error: ""`. A goal-driven run exercised real tool execution (8 commands, 2 file
  changes) 


